### PR TITLE
Apply correct icons and hover styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Client is actively developed and is currently in alpha-stage.
 
    * Install
 
-        sudo apt-get install cmake qttools5-dev libqt5svg5-dev qttools5-dev-tools libpcsclite-dev libssl-dev libdigidocpp-dev libldap2-dev
+         sudo apt-get install cmake qttools5-dev libqt5svg5-dev qttools5-dev-tools libpcsclite-dev libssl-dev libdigidocpp-dev libldap2-dev
 
 2. Fetch the source
 
@@ -68,7 +68,7 @@ Client is actively developed and is currently in alpha-stage.
 
         mkdir build
         cd build
-        cmake -DQt5_DIR="~/cmake_builds/Qt-5.9.1-OpenSSL/lib/cmake/Qt5" ..
+        cmake -DQt5_DIR="~/cmake_builds/Qt-5.9.1-OpenSSL/lib/cmake/Qt5" -DCMAKE_EXE_LINKER_FLAGS="-F/Library/Frameworks" ..
 
 4. Build
 

--- a/client/Colors.h
+++ b/client/Colors.h
@@ -19,22 +19,27 @@
 
 #pragma once
 
-#include "widgets/StyledWidget.h"
-
-namespace Ui {
-class AddressItem;
-}
-
-class AddressItem : public StyledWidget
+namespace ria
 {
-	Q_OBJECT
-
-public:
-	explicit AddressItem(ria::qdigidoc4::ContainerState state, QWidget *parent = nullptr);
-	~AddressItem();
-
-	void stateChange(ria::qdigidoc4::ContainerState state) override;
-	
-private:
-	Ui::AddressItem *ui;
-};
+namespace qdigidoc4
+{
+namespace colors
+{
+	// Blues
+	static const char* ASTRONAUT_BLUE = "#023664";
+	static const char* BAHAMA_BLUE = "#035894";
+	static const char* CURIOUS_BLUE = "#31A3D9";
+	static const char* DEEP_CERULEAN = "#006EB5";
+	static const char* LOCHMARA = "#008DCF";
+	// Reds
+	static const char* MOJO = "#981E32";
+	// Whites
+	static const char* ALABASTER = "#fafafa";
+	static const char* DARKER_ALABASTER = "#f7f7f7";
+	static const char* PORCELAIN = "#f4f5f6";
+	static const char* WHITE = "#ffffff";
+	// Golds
+	static const char* CLAY_CREEK = "#998B66";
+}
+}
+}

--- a/client/MainWindow.ui
+++ b/client/MainWindow.ui
@@ -79,7 +79,6 @@ QPushButton:disabled
 {
 background-color: transparent;
 color: #000000;
-​font-family: Open Sans;
 font-size: 13px;
 font-weight: 400;
 width: 49px;
@@ -190,11 +189,16 @@ border: none;</string>
         <widget class="QWidget" name="idSelector" native="true">
          <property name="geometry">
           <rect>
-           <x>10</x>
+           <x>5</x>
            <y>0</y>
-           <width>381</width>
+           <width>385</width>
            <height>65</height>
           </rect>
+         </property>
+         <property name="styleSheet">
+          <string notr="true">QWidget#idSelector:hover {
+    background: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 rgba(0, 118, 190, 0.15), stop: 1 rgba(255,255,255, 0.5));
+}</string>
          </property>
          <widget class="QWidget" name="selector" native="true">
           <property name="geometry">
@@ -294,9 +298,14 @@ QWidget::widget:hover { background-color: #F0F0F0 }</string>
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="styleSheet">
-            <string notr="true">border: none;
-color: #75787B;
-font-size: 11px;</string>
+            <string notr="true">QToolButton {
+  border: none;
+  color: #75787B;
+  font-size: 11px;
+}
+QToolButton:hover {
+  color: #006EB5;
+}</string>
            </property>
            <property name="text">
             <string>ABI</string>
@@ -343,9 +352,14 @@ font-size: 11px;</string>
             <cursorShape>PointingHandCursor</cursorShape>
            </property>
            <property name="styleSheet">
-            <string notr="true">border: none;
-color: #75787B;
-font-size: 11px;</string>
+            <string notr="true">QToolButton {
+  border: none;
+  color: #75787B;
+  font-size: 11px;
+}
+QToolButton:hover {
+  color: #006EB5;
+}</string>
            </property>
            <property name="text">
             <string>SEADED</string>

--- a/client/dialogs/PinPopup.cpp
+++ b/client/dialogs/PinPopup.cpp
@@ -72,7 +72,7 @@ void PinPopup::init( PinDialog::PinFlags flags, const QString &title, TokenData:
     ui->label->setFont( openSansRegular13 );
     ui->ok->setFont( openSansRegular14 );
     ui->cancel->setFont( openSansRegular14 );
-    enableOk( false );
+    ui->ok->setEnabled( false );
 
     connect( ui->ok, &QPushButton::clicked, this, &PinPopup::accept );
     connect( ui->cancel, &QPushButton::clicked, this, &PinPopup::reject );
@@ -138,7 +138,7 @@ QString PinPopup::text() const { return ui->pin->text(); }
 
 void PinPopup::textEdited( const QString &text )
 { 
-    enableOk( regexp.exactMatch( text ) ); 
+    ui->ok->setEnabled( regexp.exactMatch( text ) );
 }
 
 int PinPopup::exec()
@@ -149,16 +149,4 @@ int PinPopup::exec()
     overlay.close();
 
     return rc;
-}
-
-void PinPopup::enableOk( bool enable )
-{
-    ui->ok->setEnabled(enable);
-    // If disabled, opacity 25% applied on #006EB5
-    ui->ok->setStyleSheet(QString(
-                "border: none;"
-                "border-radius: 2px;"
-                "background-color: %1;"
-                "color: #ffffff;" ).arg( enable ? "#006EB5" : "#BFDBED" )
-            );
 }

--- a/client/dialogs/PinPopup.h
+++ b/client/dialogs/PinPopup.h
@@ -34,9 +34,9 @@ class PinPopup : public QDialog
 	Q_OBJECT
 
 public:
-	PinPopup( PinDialog::PinFlags flags, const TokenData &t, QWidget *parent = 0 );
-	PinPopup( PinDialog::PinFlags flags, const QSslCertificate &cert, TokenData::TokenFlags token, QWidget *parent = 0 );
-	PinPopup( PinDialog::PinFlags flags, const QString &title, TokenData::TokenFlags token, QWidget *parent = 0 );
+	PinPopup( PinDialog::PinFlags flags, const TokenData &t, QWidget *parent = nullptr );
+	PinPopup( PinDialog::PinFlags flags, const QSslCertificate &cert, TokenData::TokenFlags token, QWidget *parent = nullptr );
+	PinPopup( PinDialog::PinFlags flags, const QString &title, TokenData::TokenFlags token, QWidget *parent = nullptr );
 
 	~PinPopup();
 
@@ -47,7 +47,6 @@ signals:
 	void startTimer();
 
 private:
-	void enableOk( bool enable );
     void init( PinDialog::PinFlags flags, const QString &title, TokenData::TokenFlags token );
     void textEdited( const QString &text );
 

--- a/client/dialogs/PinPopup.ui
+++ b/client/dialogs/PinPopup.ui
@@ -164,11 +164,18 @@ text-align: center;</string>
     <cursorShape>PointingHandCursor</cursorShape>
    </property>
    <property name="styleSheet">
-    <string notr="true">border: none;
-border-radius: 2px;
-background-color: #981E32;
-color: #ffffff;
-text-align: center;</string>
+    <string notr="true">QPushButton {
+	border-radius: 2px; 
+	border: none;
+	color: #ffffff;
+	background-color: #981E32;
+}
+QPushButton:pressed {
+	background-color: #F24A66;
+}
+QPushButton:hover:!pressed {
+	background-color: #CD2541;
+}</string>
    </property>
    <property name="text">
     <string>Cancel</string>
@@ -201,11 +208,21 @@ text-align: center;</string>
     </font>
    </property>
    <property name="styleSheet">
-    <string notr="true">border: none;
-border-radius: 2px;
-background-color: #006EB5;
-color: #ffffff;
-text-align: center;</string>
+    <string notr="true">QPushButton {
+	border-radius: 2px; 
+	border: none;
+	color: #ffffff;
+	background-color: #006EB5;
+}
+QPushButton:pressed {
+	background-color: #41B6E6;
+}
+QPushButton:hover:!pressed {
+	background-color: #008DCF;
+}
+QPushButton:disabled {
+	background-color: #BEDBED;
+}</string>
    </property>
    <property name="text">
     <string>Ok</string>

--- a/client/dialogs/PinUnblock.cpp
+++ b/client/dialogs/PinUnblock.cpp
@@ -46,7 +46,7 @@ void PinUnblock::init(PinDialog::PinFlags flags)
     setWindowFlags( Qt::Dialog | Qt::FramelessWindowHint );
     setWindowModality( Qt::ApplicationModal );
 
-    disableUnblock();
+    ui->unblock->setEnabled( false );
     connect( ui->unblock, &QPushButton::clicked, this, &PinUnblock::accept );
     connect( ui->cancel, &QPushButton::clicked, this, &PinUnblock::reject );
     connect( this, &PinUnblock::finished, this, &PinUnblock::close );
@@ -92,11 +92,9 @@ void PinUnblock::init(PinDialog::PinFlags flags)
     QFont headerFont( Styles::font( Styles::Regular, 20 ) );
     headerFont.setWeight( QFont::DemiBold );
     ui->labelNameId->setFont( headerFont );
-    ui->cancel->setFont( condensed14 );
     ui->unblock->setFont( condensed14 );
     ui->label->setFont( Styles::font( Styles::Regular, 14 ) );
     ui->labelPuk->setFont( Styles::font( Styles::Condensed, 12 ) );
-
 
     connect(ui->puk, &QLineEdit::textChanged, this,
                 [this](const QString &text)
@@ -152,35 +150,7 @@ void PinUnblock::setUnblockEnabled()
         ui->iconLabelRepeat->setStyleSheet("");
     }
 
-    if(isPukOk && isPinOk && isRepeatOk)
-    {
-        enableUnblock();
-    }
-    else
-    {
-        disableUnblock();
-    }
-}
-
-void PinUnblock::disableUnblock()
-{
-    ui->unblock->setEnabled(false);
-    // Opacity 25% applied on #006EB5
-    ui->unblock->setStyleSheet(
-                "border-radius: 2px;"
-                "background-color: #BFDBED;"
-                "color: #ffffff;"
-                );
-}
-
-void PinUnblock::enableUnblock()
-{
-    ui->unblock->setEnabled(true);
-    ui->unblock->setStyleSheet(
-                "border-radius: 2px;"
-                "background-color: #006EB5;"
-                "color: #ffffff;"
-            );
+    ui->unblock->setEnabled( isPukOk && isPinOk && isRepeatOk );
 }
 
 int PinUnblock::exec()

--- a/client/dialogs/PinUnblock.h
+++ b/client/dialogs/PinUnblock.h
@@ -38,8 +38,6 @@ public:
     int exec() override;
 
 private:
-    void disableUnblock();
-    void enableUnblock();
     void init(PinDialog::PinFlags flags);
     void setUnblockEnabled();
 

--- a/client/dialogs/PinUnblock.ui
+++ b/client/dialogs/PinUnblock.ui
@@ -51,9 +51,18 @@ background-color: #FFFFFF;</string>
     <cursorShape>PointingHandCursor</cursorShape>
    </property>
    <property name="styleSheet">
-    <string notr="true">border-radius: 2px;
-background-color: #981E32;
-color: #ffffff;</string>
+    <string notr="true">QPushButton {
+	border-radius: 2px; 
+	border: none;
+	color: #ffffff;
+	background-color: #981E32;
+}
+QPushButton:pressed {
+	background-color: #F24A66;
+}
+QPushButton:hover:!pressed {
+	background-color: #CD2541;
+}</string>
    </property>
    <property name="text">
     <string>KATKESTA</string>
@@ -78,9 +87,21 @@ color: #ffffff;</string>
     <cursorShape>PointingHandCursor</cursorShape>
    </property>
    <property name="styleSheet">
-    <string notr="true">border-radius: 2px;
-background-color: #006EB5;
-color: #ffffff;</string>
+    <string notr="true">QPushButton {
+	border-radius: 2px; 
+	border: none;
+	color: #ffffff;
+	background-color: #006EB5;
+}
+QPushButton:pressed {
+	background-color: #41B6E6;
+}
+QPushButton:hover:!pressed {
+	background-color: #008DCF;
+}
+QPushButton:disabled {
+	background-color: #BEDBED;
+}</string>
    </property>
    <property name="text">
     <string>BLOKEERI LAHTI</string>
@@ -228,7 +249,6 @@ line-height: 16px;</string>
     <string notr="true">padding: 0px 10px;
 border: 1px solid #c8c8c8;
 background-color: #ffffff;
-font-family: Arial;
 font-size: 14px;
 color: #000000;
 font-weight: 400;
@@ -273,7 +293,6 @@ line-height: 14px;</string>
      <widget class="QLabel" name="labelPin">
       <property name="styleSheet">
        <string notr="true">color: #353739;
-font-family: Roboto Condensed;
 font-size: 12px;</string>
       </property>
       <property name="text">
@@ -325,7 +344,6 @@ font-size: 12px;</string>
     <string notr="true">padding: 0px 10px;
 border: 1px solid #c8c8c8;
 background-color: #ffffff;
-font-family: Arial;
 font-size: 14px;
 color: #000000;
 font-weight: 400;
@@ -367,7 +385,6 @@ line-height: 14px;</string>
      <widget class="QLabel" name="labelRepeat">
       <property name="styleSheet">
        <string notr="true">color: #353739;
-font-family: Roboto Condensed;
 font-size: 12px;</string>
       </property>
       <property name="text">
@@ -419,7 +436,6 @@ font-size: 12px;</string>
     <string notr="true">padding: 0px 10px;
 border: 1px solid #c8c8c8;
 background-color: #ffffff;
-font-family: Arial;
 font-size: 14px;
 color: #000000;
 font-weight: 400;

--- a/client/images/icon_Edit_pressed.svg
+++ b/client/images/icon_Edit_pressed.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="17px" height="19px" viewBox="0 0 17 19" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 46.2 (44496) - http://www.bohemiancoding.com/sketch -->
+    <title>Icon_Edit</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Buttons&amp;Icons" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="eID" transform="translate(-191.000000, -312.000000)">
+            <g id="Icon_Edit" transform="translate(189.000000, 312.000000)">
+                <g id="Group-5" stroke-width="1" transform="translate(9.500000, 9.500000) rotate(-315.000000) translate(-9.500000, -9.500000) translate(7.000000, -1.000000)" stroke="#FFFFFF">
+                    <polyline id="Path-2" points="0.5 16 0.5 3.5 4.5 3.5 4.5 16"></polyline>
+                    <path d="M0.902123821,17.5 L2.5,20.0566019 L4.09787618,17.5 L0.902123821,17.5 Z" id="Path-3"></path>
+                    <path d="M0.5,2 L0.5,1.5 C0.5,0.94771525 0.94771525,0.5 1.5,0.5 L3.5,0.5 C4.05228475,0.5 4.5,0.94771525 4.5,1.5 L4.5,2" id="Path-4"></path>
+                </g>
+                <rect id="Rectangle" fill="#FFFFFF" x="2" y="18" width="16" height="1"></rect>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/client/images/images.qrc
+++ b/client/images/images.qrc
@@ -20,6 +20,7 @@
 		<file>icon_download_hover.svg</file>
 		<file>icon_download.svg</file>
 		<file>icon_Edit_hover.svg</file>
+		<file>icon_Edit_pressed.svg</file>
 		<file>icon_Edit.svg</file>
 		<file>icon_IDkaart_disabled.svg</file>
 		<file>icon_IDkaart_red.svg</file>

--- a/client/widgets/Accordion.h
+++ b/client/widgets/Accordion.h
@@ -33,7 +33,7 @@ class Accordion : public QWidget
 	Q_OBJECT
 
 public:
-	explicit Accordion( QWidget *parent = 0 );
+	explicit Accordion( QWidget *parent = nullptr );
 	~Accordion();
 
 	void init();

--- a/client/widgets/AccordionTitle.h
+++ b/client/widgets/AccordionTitle.h
@@ -39,7 +39,7 @@ class AccordionTitle : public StyledWidget
 	Q_OBJECT
 
 public:
-	explicit AccordionTitle(QWidget *parent = 0);
+	explicit AccordionTitle(QWidget *parent = nullptr);
 	~AccordionTitle();
 
 	void init(Accordion* accordion, bool open, const QString& caption, QWidget* content);

--- a/client/widgets/CardInfo.cpp
+++ b/client/widgets/CardInfo.cpp
@@ -21,6 +21,7 @@
 #include "ui_CardInfo.h"
 #include "common_enums.h"
 #include "Styles.h"
+#include "widgets/LabelButton.h"
 
 using namespace ria::qdigidoc4;
 
@@ -34,7 +35,7 @@ CardInfo::CardInfo( QWidget *parent )
 	ui->cardName->setFont( Styles::font( Styles::Condensed, 20, QFont::DemiBold ) );
 	ui->cardCode->setFont( font );
 	ui->cardStatus->setFont( font );
-	ui->cardPhoto->init( CardPhoto );
+	ui->cardPhoto->init( LabelButton::None, "", CardPhoto );
 
 	cardIcon.reset( new QSvgWidget( ":/images/icon_IDkaart.svg", this ) );
 	cardIcon->resize( 17, 12 );

--- a/client/widgets/CardInfo.h
+++ b/client/widgets/CardInfo.h
@@ -34,7 +34,7 @@ class CardInfo : public QWidget
     Q_OBJECT
 
 public:
-    explicit CardInfo( QWidget *parent = 0 );
+    explicit CardInfo( QWidget *parent = nullptr );
     ~CardInfo();
 
 	void clearPicture();

--- a/client/widgets/CardInfo.ui
+++ b/client/widgets/CardInfo.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>321</width>
+    <width>325</width>
     <height>65</height>
    </rect>
   </property>
@@ -25,7 +25,7 @@
   <widget class="QLabel" name="cardName">
    <property name="geometry">
     <rect>
-     <x>45</x>
+     <x>49</x>
      <y>7</y>
      <width>273</width>
      <height>24</height>
@@ -50,7 +50,7 @@
     </font>
    </property>
    <property name="styleSheet">
-    <string notr="true">color: #041E42;</string>
+    <string notr="true">color: #041E42; background: none;</string>
    </property>
    <property name="text">
     <string>MARI MAASIKAS MUSTIKAS</string>
@@ -59,7 +59,7 @@
   <widget class="QLabel" name="cardCode">
    <property name="geometry">
     <rect>
-     <x>45</x>
+     <x>49</x>
      <y>38</y>
      <width>116</width>
      <height>19</height>
@@ -71,7 +71,7 @@
     </font>
    </property>
    <property name="styleSheet">
-    <string notr="true">color: #75787B;</string>
+    <string notr="true">color: #75787B; background: none;</string>
    </property>
    <property name="text">
     <string>48405050123 |</string>
@@ -80,7 +80,7 @@
   <widget class="QLabel" name="cardStatus">
    <property name="geometry">
     <rect>
-     <x>181</x>
+     <x>185</x>
      <y>38</y>
      <width>135</width>
      <height>19</height>
@@ -92,7 +92,7 @@
     </font>
    </property>
    <property name="styleSheet">
-    <string notr="true">color: #75787B;</string>
+    <string notr="true">color: #75787B; background: none;</string>
    </property>
    <property name="text">
     <string>Lugejas on ID kaart</string>
@@ -101,7 +101,7 @@
   <widget class="LabelButton" name="cardPhoto">
    <property name="geometry">
     <rect>
-     <x>1</x>
+     <x>5</x>
      <y>10</y>
      <width>34</width>
      <height>45</height>

--- a/client/widgets/ContainerPage.cpp
+++ b/client/widgets/ContainerPage.cpp
@@ -52,6 +52,9 @@ void ContainerPage::init()
 	QFont regular = Styles::font( Styles::Regular, 14 );
 	ui->warningText->setFont( regular );
 	ui->warningAction->setFont( Styles::font( Styles::Regular, 14, QFont::Bold ) );
+	ui->container->setFont( regular );
+	ui->containerFile->setFont( regular );
+
 	QGraphicsDropShadowEffect *shadow = new QGraphicsDropShadowEffect();
 	shadow->setColor( QColor( 233, 200, 143 ) );
 	shadow->setXOffset( 4 );
@@ -59,15 +62,13 @@ void ContainerPage::init()
 	ui->warning->setGraphicsEffect( shadow );
 	ui->containerHeader->setGraphicsEffect( shadow );
 
-	ui->container->setFont( regular );
-	ui->containerFile->setFont( regular );
-	ui->changeLocation->setIcons( "/images/icon_Edit.svg", "/images/icon_Edit_hover.svg", 4, 4, 18, 18 );
-	ui->changeLocation->init( LabelButton::DeepCerulean | LabelButton::PorcelainBackground, "MUUDA", Actions::ContainerLocation );
-	ui->cancel->init( LabelButton::Mojo, "← KATKESTA", Actions::ContainerCancel );
-	ui->encrypt->init( LabelButton::DeepCerulean, "KRÜPTEERI", Actions::ContainerEncrypt );
-	ui->navigateToContainer->init( LabelButton::DeepCerulean, "AVA KONTAINERI ASUKOHT", Actions::ContainerNavigate );
-	ui->email->init( LabelButton::DeepCerulean, "EDASTA E-MAILIGA", Actions::ContainerEmail );
-	ui->save->init( LabelButton::DeepCerulean, "SALVESTA ALLKIRJASTAMATA", Actions::ContainerSave );
+	ui->changeLocation->setIcons( "/images/icon_Edit.svg", "/images/icon_Edit_hover.svg", "/images/icon_Edit_pressed.svg", 4, 4, 18, 18 );
+	ui->changeLocation->init( LabelButton::BoxedDeepCeruleanWithCuriousBlue, "MUUDA", Actions::ContainerLocation );
+	ui->cancel->init( LabelButton::BoxedMojo, "← KATKESTA", Actions::ContainerCancel );
+	ui->encrypt->init( LabelButton::BoxedDeepCerulean, "KRÜPTEERI", Actions::ContainerEncrypt );
+	ui->navigateToContainer->init( LabelButton::BoxedDeepCerulean, "AVA KONTAINERI ASUKOHT", Actions::ContainerNavigate );
+	ui->email->init( LabelButton::BoxedDeepCerulean, "EDASTA E-MAILIGA", Actions::ContainerEmail );
+	ui->save->init( LabelButton::BoxedDeepCerulean, "SALVESTA ALLKIRJASTAMATA", Actions::ContainerSave );
 
 	connect( ui->cancel, &LabelButton::clicked, this, &ContainerPage::action );
 }

--- a/client/widgets/ContainerPage.h
+++ b/client/widgets/ContainerPage.h
@@ -39,7 +39,7 @@ class ContainerPage : public QWidget
 	Q_OBJECT
 
 public:
-	explicit ContainerPage( QWidget *parent = 0 );
+	explicit ContainerPage( QWidget *parent = nullptr );
 	~ContainerPage();
 
 	void transition( ria::qdigidoc4::ContainerState state, const QStringList &files = QStringList() );

--- a/client/widgets/ContainerPage.ui
+++ b/client/widgets/ContainerPage.ui
@@ -572,7 +572,7 @@ color: #c53e3e;
 text-decoration: none solid rgb(197, 62, 62);</string>
         </property>
         <property name="text">
-         <string>KATKESTA</string>
+         <string>← KATKESTA</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>

--- a/client/widgets/FileItem.h
+++ b/client/widgets/FileItem.h
@@ -30,8 +30,8 @@ class FileItem : public StyledWidget
 	Q_OBJECT
 
 public:
-	explicit FileItem( ria::qdigidoc4::ContainerState state, QWidget *parent = 0 );
-	explicit FileItem( const QString& file, ria::qdigidoc4::ContainerState state, QWidget *parent = 0 );
+	explicit FileItem( ria::qdigidoc4::ContainerState state, QWidget *parent = nullptr );
+	explicit FileItem( const QString& file, ria::qdigidoc4::ContainerState state, QWidget *parent = nullptr );
 	~FileItem();
 
 	void stateChange(ria::qdigidoc4::ContainerState state) override;

--- a/client/widgets/InfoStack.h
+++ b/client/widgets/InfoStack.h
@@ -34,7 +34,7 @@ class InfoStack : public StyledWidget
 	Q_OBJECT
 
 public:
-	explicit InfoStack(QWidget *parent = 0);
+	explicit InfoStack(QWidget *parent = nullptr);
 	~InfoStack();
 
 	void clearPicture();

--- a/client/widgets/ItemList.cpp
+++ b/client/widgets/ItemList.cpp
@@ -115,7 +115,7 @@ void ItemList::init( ItemType item, const QString &header )
 	} 
 	else
 	{
-		ui->add->init(LabelButton::DeepCerulean | LabelButton::WhiteBackground, addLabel(), itemType == File ? FileAdd : AddressAdd);
+		ui->add->init(LabelButton::DeepCeruleanWithLochmara, addLabel(), itemType == File ? FileAdd : AddressAdd);
 		ui->add->setFont(Styles::font(Styles::Condensed, 12));
 	}
 }

--- a/client/widgets/ItemList.h
+++ b/client/widgets/ItemList.h
@@ -39,7 +39,7 @@ public:
 		Address
 	};
 
-	explicit ItemList(QWidget *parent = 0);
+	explicit ItemList(QWidget *parent = nullptr);
 	virtual ~ItemList();
 
 	void init(ItemType itemType, const QString &header);

--- a/client/widgets/ItemList.ui
+++ b/client/widgets/ItemList.ui
@@ -244,10 +244,13 @@ border-width: 0px 1px 0px 0px; </string>
             <number>0</number>
            </property>
            <property name="text">
-            <string>&lt;a href=&quot;#add-files&quot; style=&quot;color: #006eb5; text-decoration: none solid rgb(0, 110, 181);&quot;&gt;+ LISA VEEL FAILE&lt;/a&gt;</string>
+            <string>+ LISA VEEL FAILE</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignCenter</set>
+           </property>
+           <property name="margin">
+            <number>0</number>
            </property>
           </widget>
          </item>

--- a/client/widgets/LabelButton.h
+++ b/client/widgets/LabelButton.h
@@ -25,27 +25,25 @@
 #include <memory>
 
 
-// A label that acts as a button.
-// LabelButton switches foreground color with background when mouse hovers over it.
+// A label with pre-defined styles that acts as a button.
+// LabelButton changes style (colors) on hover and when pressed.
 class LabelButton : public QLabel
 {
     Q_OBJECT
 
 public:
-    enum ButtonStyle {
-        Mojo = (1 << 0),
-        DeepCerulean = (1 << 1),
-        WhiteBackground = (1 << 2),
-        AlabasterBackground = (1 << 3),
-        PorcelainBackground = (1 << 4)
+    enum Style {
+        BoxedDeepCerulean,
+        BoxedMojo,
+        BoxedDeepCeruleanWithCuriousBlue, // Edit
+        DeepCeruleanWithLochmara, // Add files
+        None
     };
-
+    
     explicit LabelButton(QWidget *parent = nullptr);
 
-    void init( int code );
-    void init( int style, const QString &label, int code );
-    void setIcons( const QString &normalIcon, const QString &hoverIcon, int x, int y, int w, int h );
-    void setStyles( const QString &nStyle, const QString &nLink, const QString &style, const QString &link );
+    void init( Style style, const QString &label, int code );
+    void setIcons( const QString &normalIcon, const QString &hoverIcon, const QString &pressedIcon, int x, int y, int w, int h );
 
 signals:
     void clicked(int code);
@@ -56,12 +54,23 @@ protected:
     bool event( QEvent *ev ) override;
 
 private:
+    struct Css {
+        QString style;
+        QString background;
+        QString icon;
+    };
+    enum State {
+        Normal,
+        Hover,
+        Pressed
+    };
     void normal();
-    QString background(int style) const;
-    QString foreground(int style) const;
-
+    void hover();
+    void pressed();
+    
     int code;
     int style;
+    Css css[3];
     QString normalStyle;
     QString normalLink;
     QString normalIcon;

--- a/client/widgets/MainAction.ui
+++ b/client/widgets/MainAction.ui
@@ -64,7 +64,18 @@ background-color: #1a7dbc;
       <cursorShape>PointingHandCursor</cursorShape>
      </property>
      <property name="styleSheet">
-      <string notr="true">border: none; color: #FFFFFF; background-color: #006EB5;</string>
+      <string notr="true">QPushButton {
+	border: none;
+	color: #ffffff;
+	background-color: #006EB5;
+}
+QPushButton:pressed {
+	background-color: #41B6E6;
+}
+QPushButton:hover:!pressed {
+	background-color: #008DCF;
+}
+</string>
      </property>
      <property name="text">
       <string>ALLKIRJASTA
@@ -90,10 +101,18 @@ ID-KAARDIGA</string>
       <cursorShape>PointingHandCursor</cursorShape>
      </property>
      <property name="styleSheet">
-      <string notr="true">/* border: none; */
-border: solid #1a7dbc;
-border-width: 0px 0px 0px 1px;
-background-color: #006EB5;</string>
+      <string notr="true">QToolButton {
+	border: solid #1a7dbc;
+	border-width: 0px 0px 0px 1px;
+	background-color: #006EB5;
+}
+QToolButton:pressed {
+	background-color: #41B6E6;
+}
+QToolButton:hover:!pressed {
+	background-color: #008DCF;
+}
+</string>
      </property>
      <property name="text">
       <string/>

--- a/client/widgets/NoCardInfo.h
+++ b/client/widgets/NoCardInfo.h
@@ -35,7 +35,7 @@ class NoCardInfo : public QWidget
     Q_OBJECT
 
 public:
-    explicit NoCardInfo( QWidget *parent = 0 );
+    explicit NoCardInfo( QWidget *parent = nullptr );
     ~NoCardInfo();
 
     void update( const QString &status );

--- a/client/widgets/OtherData.cpp
+++ b/client/widgets/OtherData.cpp
@@ -40,6 +40,13 @@ OtherData::OtherData(QWidget *parent) :
 	ui->labelEestiEe->setFont( Styles::font( Styles::Regular, 12 ) );
 	ui->activate->setFont( condensed );
 	ui->btnCheckEMail->setFont( condensed );
+	ui->activate->setStyleSheet(
+			"padding: 6px 9px;"
+			"QPushButton { border-radius: 2px; border: none; color: #ffffff; background-color: #006EB5;}"
+			"QPushButton:pressed { background-color: #41B6E6;}"
+			"QPushButton:hover:!pressed { background-color: #008DCF;}"
+			"QPushButton:disabled { background-color: #BEDBED;};"
+			);
 }
 
 OtherData::~OtherData()
@@ -60,30 +67,12 @@ void OtherData::update( bool activate, const QString &eMail, const quint8 &error
 
 		if( ui->inputEMail->text().isEmpty() )
 		{
-			ui->activate->setStyleSheet(
-						"padding: 6px 9px;"
-						"border: 1px;"
-						"border-style: solid;"
-						"border-radius: 2px;"
-						"border-color: #50a7d2;"
-						"background-color: #ffffff;"
-						"color: #50a7d2;"
-						"text-align: center;"
-						);
+			ui->activate->setDisabled( true );
 			ui->activate->setCursor( Qt::ArrowCursor );
 		}
 		else
 		{
-			ui->activate->setStyleSheet(
-						"padding: 6px 9px;"
-						"border: 1px;"
-						"border-style: solid;"
-						"border-radius: 2px;"
-						"border-color: #006eb5;"
-						"background-color: #ffffff;"
-						"color: #006eb5;"
-						"text-align: center;"
-						);
+			ui->activate->setDisabled( false );
 			ui->activate->setCursor( Qt::PointingHandCursor );
 		}
 		ui->inputEMail->setFocus();

--- a/client/widgets/OtherData.h
+++ b/client/widgets/OtherData.h
@@ -31,7 +31,7 @@ class OtherData : public QWidget
 	Q_OBJECT
 
 public:
-	explicit OtherData( QWidget *parent = 0 );
+	explicit OtherData( QWidget *parent = nullptr );
 	~OtherData();
 
 	void update( bool activate, const QString &eMail = "", const quint8 &errorCode = 0 );

--- a/client/widgets/OtherData.ui
+++ b/client/widgets/OtherData.ui
@@ -60,14 +60,11 @@ color: #353739;</string>
       </font>
      </property>
      <property name="styleSheet">
-      <string notr="true">padding: 6px 9px;
-border: 1px;
-border-style: solid;
-border-radius: 2px;
-border-color: #006eb5;
-background-color: #ffffff;
-color: #006eb5;
-text-align: center;</string>
+      <string notr="true">QPushButton { padding: 6px 9px; border-radius: 2px; border: 1px solid #006EB5; color: #006EB5; background-color: #FFFFFF;}
+QPushButton:pressed { border: 1px solid #41B6E6; color: #41B6E6;}
+QPushButton:hover:!pressed { border: 1px solid #008DCF; color: #008DCF;}
+QPushButton:disabled { border: 1px solid #BEDBED; color: #BEDBED;};
+</string>
      </property>
      <property name="text">
       <string>KONTROLLI @EESTI.EE E-POSTI STAATUST</string>
@@ -146,7 +143,6 @@ color: #353739;</string>
         </property>
         <property name="styleSheet">
          <string notr="true">border: 1px solid #c8c8c8;
-font-family: Arial;
 font-size: 14px;
 color: #000000;
 font-weight: 400;
@@ -176,14 +172,11 @@ text-decoration: underline;
          </font>
         </property>
         <property name="styleSheet">
-         <string notr="true">padding: 6px 9px;
-border: 1px;
-border-style: solid;
-border-radius: 2px;
-border-color: #006eb5;
-background-color: #ffffff;
-color: #006eb5;
-text-align: center;</string>
+         <string notr="true">QPushButton { padding: 6px 9px; border-radius: 2px; border: 1px solid #006EB5; color: #006EB5; background-color: #FFFFFF;}
+QPushButton:pressed { border: 1px solid #41B6E6; color: #41B6E6;}
+QPushButton:hover:!pressed { border: 1px solid #008DCF; color: #008DCF;}
+QPushButton:disabled { border: 1px solid #BEDBED; color: #BEDBED;};
+</string>
         </property>
         <property name="text">
          <string>AKTIVEERI SUUNAMINE</string>

--- a/client/widgets/PageIcon.cpp
+++ b/client/widgets/PageIcon.cpp
@@ -19,6 +19,7 @@
 
 #include "PageIcon.h"
 #include "ui_PageIcon.h"
+#include "Colors.h"
 #include "Styles.h"
 
 #include <QPainter>
@@ -47,22 +48,25 @@ void PageIcon::init( Pages type, QWidget *shadow,  bool selected )
 	switch( type )
 	{
 	case CryptoIntro:
-		active = PageIcon::Style { font, "/images/icon_Krypto_hover.svg", "#ffffff", "#998B66" };
-		inactive = PageIcon::Style { font, "/images/icon_Krypto.svg", "#023664", "#ffffff" };
+		active = PageIcon::Style { font, "/images/icon_Krypto_hover.svg", colors::WHITE, colors::CLAY_CREEK };
+		hover = PageIcon::Style { font, "/images/icon_Krypto_hover.svg", colors::BAHAMA_BLUE, colors::WHITE };
+		inactive = PageIcon::Style { font, "/images/icon_Krypto.svg", colors::ASTRONAUT_BLUE, colors::WHITE };
 		icon->resize( 34, 38 );
 		icon->move( 38, 26 );	
 		ui->label->setText( "KRÜPTO" );
 		break;
 	case MyEid:
-		active = PageIcon::Style { font, "/images/icon_Minu_eID_hover.svg", "#ffffff", "#998B66" };
-		inactive = PageIcon::Style { font, "/images/icon_Minu_eID.svg", "#023664", "#ffffff" };
+		active = PageIcon::Style { font, "/images/icon_Minu_eID_hover.svg", colors::WHITE, colors::CLAY_CREEK };
+		hover = PageIcon::Style { font, "/images/icon_Minu_eID_hover.svg", colors::BAHAMA_BLUE, colors::WHITE };
+		inactive = PageIcon::Style { font, "/images/icon_Minu_eID.svg", colors::ASTRONAUT_BLUE, colors::WHITE };
 		icon->resize( 44, 31 );
 		icon->move( 33, 28 );	
 		ui->label->setText( "MINU eID" );
 		break;
 	default:
-		active = PageIcon::Style { font, "/images/icon_Allkiri_hover.svg", "#ffffff", "#998B66" };
-		inactive = PageIcon::Style { font, "/images/icon_Allkiri.svg", "#023664", "#ffffff" };
+		active = PageIcon::Style { font, "/images/icon_Allkiri_hover.svg", colors::WHITE, colors::CLAY_CREEK };
+		hover = PageIcon::Style { font, "/images/icon_Allkiri_hover.svg", colors::BAHAMA_BLUE, colors::WHITE };
+		inactive = PageIcon::Style { font, "/images/icon_Allkiri.svg", colors::ASTRONAUT_BLUE, colors::WHITE };
 		ui->label->setText( "ALLKIRI" );
 		break;
 	}
@@ -82,6 +86,26 @@ void PageIcon::activate( bool selected )
 Pages PageIcon::getType()
 {
 	return type;
+}
+
+void PageIcon::enterEvent( QEvent *ev )
+{
+	if( !selected )
+	{
+		icon->setStyleSheet(QString("background-color: %1; border: none;").arg(hover.backColor));	
+		setStyleSheet(QString("background-repeat: none; background-color: %1; border: none;").arg(hover.backColor));
+		ui->label->setStyleSheet( QString("background-color: %1; color: %2; border: none;").arg(hover.backColor).arg(hover.foreColor) );
+	}
+}
+
+void PageIcon::leaveEvent( QEvent *ev )
+{
+	if( !selected )
+	{
+		icon->setStyleSheet(QString("background-color: %1; border: none;").arg(inactive.backColor));	
+		setStyleSheet(QString("background-repeat: none; background-color: %1; border: none;").arg(inactive.backColor));
+		ui->label->setStyleSheet( QString("background-color: %1; color: %2; border: none;").arg(inactive.backColor).arg(inactive.foreColor) );
+	}
 }
 
 void PageIcon::mouseReleaseEvent(QMouseEvent *event)
@@ -106,7 +130,7 @@ void PageIcon::updateSelection()
 	ui->label->setFont(style.font);
 	ui->label->setStyleSheet( QString("background-color: %1; color: %2; border: none;").arg(style.backColor).arg(style.foreColor) );
 	icon->load( QString( ":%1" ).arg( style.image ) );
-	icon->setStyleSheet(QString("background-color: %1; border: none;").arg(style.backColor));	
+	icon->setStyleSheet(QString("background-color: %1; border: none;").arg(style.backColor));
 	setStyleSheet(QString("background-repeat: none; background-color: %1; border: none;").arg(style.backColor));
 }
 

--- a/client/widgets/PageIcon.h
+++ b/client/widgets/PageIcon.h
@@ -39,7 +39,7 @@ class PageIcon : public QWidget
 	Q_OBJECT
 
 public:
-	explicit PageIcon( QWidget *parent = 0 );
+	explicit PageIcon( QWidget *parent = nullptr );
 	~PageIcon();
 
 	void init( ria::qdigidoc4::Pages page, QWidget *shadow, bool selected );
@@ -50,6 +50,8 @@ signals:
 	void activated( PageIcon *const );
 
 protected:
+	void enterEvent( QEvent *ev ) override;
+	void leaveEvent( QEvent *ev ) override;
 	void mouseReleaseEvent( QMouseEvent *event ) override;
 	void paintEvent( QPaintEvent *ev ) override;
 
@@ -65,6 +67,7 @@ private:
 	std::unique_ptr<QSvgWidget> icon;
 	Style active;
 	Style inactive;
+	Style hover;
 	bool selected;
 	ria::qdigidoc4::Pages type;
 

--- a/client/widgets/SignatureItem.h
+++ b/client/widgets/SignatureItem.h
@@ -30,7 +30,7 @@ class SignatureItem : public StyledWidget
 	Q_OBJECT
 
 public:
-	explicit SignatureItem(ria::qdigidoc4::ContainerState state, QWidget *parent = 0);
+	explicit SignatureItem(ria::qdigidoc4::ContainerState state, QWidget *parent = nullptr);
 	~SignatureItem();
 
 	void stateChange(ria::qdigidoc4::ContainerState state) override;

--- a/client/widgets/StyledWidget.h
+++ b/client/widgets/StyledWidget.h
@@ -30,7 +30,7 @@ class StyledWidget : public QWidget
 	Q_OBJECT
 
 public:
-	explicit StyledWidget(QWidget *parent = 0);
+	explicit StyledWidget(QWidget *parent = nullptr);
 	~StyledWidget();
 
 	virtual void stateChange(ria::qdigidoc4::ContainerState state) {};

--- a/client/widgets/VerifyCert.cpp
+++ b/client/widgets/VerifyCert.cpp
@@ -59,17 +59,7 @@ void VerifyCert::update(bool isValid, const QString &name, const QString &validU
 		this->setStyleSheet("background-color: #ffffff;" + borders);
 		ui->verticalSpacerAboveBtn->changeSize( 20, 32 );
 		ui->verticalSpacerBelowBtn->changeSize( 20, 38 );
-		ui->changePIN->setStyleSheet(
-					"border: 1px solid #4a82f3;"
-					"padding: 6px 10px;"
-					"border-radius: 3px;"
-					"background-color: #4a82f3;"
-					"font-family: Open Sans;"
-					"font-size: 14px;"
-					"color: #ffffff;"
-					"font-weight: 400;"
-					"text-align: center;"
-					);
+		changePinStyle( "#FFFFFF" );
 	}
 	else
 	{
@@ -79,15 +69,10 @@ void VerifyCert::update(bool isValid, const QString &name, const QString &validU
 		ui->verticalSpacerAboveBtn->changeSize( 20, 8 );
 		ui->verticalSpacerBelowBtn->changeSize( 20, 6 );
 		ui->changePIN->setStyleSheet(
-					"border: 1px solid #53c964;"
-					"padding: 6px 10px;"
-					"border-radius: 3px;"
-					"background-color: #53c964;"
-					"font-family: Open Sans;"
-					"font-size: 14px;"
-					"color: #ffffff;"
-					"font-weight: 400;"
-					"text-align: center;"
+					"QPushButton { border-radius: 2px; border: none; color: #ffffff; background-color: #006EB5;}"
+					"QPushButton:pressed { background-color: #41B6E6;}"
+					"QPushButton:hover:!pressed { background-color: #008DCF;}"
+					"QPushButton:disabled { background-color: #BEDBED;};"
 					);
 	}
 
@@ -131,15 +116,30 @@ void VerifyCert::update(bool isValid, const QString &name, const QString &validU
 void VerifyCert::enterEvent(QEvent * event)
 {
 	if(isValid)
+	{
 		this->setStyleSheet("background-color: #f7f7f7;" + borders);
+		changePinStyle( "#f7f7f7" );
+	}
 }
 
 void VerifyCert::leaveEvent(QEvent * event)
 {
 	if(isValid)
+	{
 		this->setStyleSheet("background-color: white;" + borders);
+		changePinStyle( "white" );
+	}
 }
 
+void VerifyCert::changePinStyle( const QString &background )
+{
+	ui->changePIN->setStyleSheet(
+		QString("QPushButton { border-radius: 2px; border: 1px solid #006EB5; color: #006EB5; background-color: %1;}"
+		"QPushButton:pressed { border: 1px solid #41B6E6; color: #41B6E6;}"
+		"QPushButton:hover:!pressed { border: 1px solid #008DCF; color: #008DCF;}"
+		"QPushButton:disabled { border: 1px solid #BEDBED; color: #BEDBED;};").arg( background )
+		);
+}
 
 // Needed to setStyleSheet() take effect.
 void VerifyCert::paintEvent(QPaintEvent *)

--- a/client/widgets/VerifyCert.h
+++ b/client/widgets/VerifyCert.h
@@ -31,7 +31,7 @@ class VerifyCert : public QWidget
 	Q_OBJECT
 
 public:
-	explicit VerifyCert(QWidget *parent = 0);
+	explicit VerifyCert(QWidget *parent = nullptr);
 	~VerifyCert();
 
 	void update(bool isValid, const QString &name, const QString &validUntil, const QString &change, const QString &forgot_PIN_HTML = "", const QString &details_HTML = "", const QString &error = "");
@@ -47,6 +47,8 @@ protected:
 	void leaveEvent(QEvent * event) override;
 
 private:
+	void changePinStyle( const QString &background );
+
 	Ui::VerifyCert *ui;
 	bool isValid;
 	QString borders;

--- a/client/widgets/VerifyCert.ui
+++ b/client/widgets/VerifyCert.ui
@@ -176,7 +176,6 @@
         <property name="styleSheet">
          <string notr="true">padding: 6px 6px 6px 6px;
 line-height: 14px;
-box-sizing: border-box;
 border: 1px solid #E9CB8F;
 border-radius: 2px;
 background-color: #F8DDA7;

--- a/patches/qt-5.9.1-xcode-9.patch
+++ b/patches/qt-5.9.1-xcode-9.patch
@@ -1,0 +1,74 @@
+From 861544583511d4e6f7745d2339b26ff1cd44132b Mon Sep 17 00:00:00 2001
+From: Jake Petroules <jake.petroules@qt.io>
+Date: Wed, 2 Aug 2017 12:56:44 -0700
+Subject: [PATCH] Fix build error with macOS 10.13 SDK
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf8
+Content-Transfer-Encoding: 8bit
+
+Several of these variables/macros are no longer defined. We didn't
+validate the preconditions on iOS, tvOS, or watchOS, so no
+need to bother validating them on macOS either. Nor did we check the
+OSStatus result on any platform anyways.
+
+Task-number: QTBUG-62266
+Change-Id: Id19ebead5d3a8a08a0a56d798f0173d0d893fc91
+Reviewed-by: Tony SarajÃ¤rvi <tony.sarajarvi@qt.io>
+---
+ src/gui/painting/qcoregraphics.mm  | 18 +-----------------
+ src/gui/painting/qcoregraphics_p.h |  2 +-
+ 2 files changed, 2 insertions(+), 18 deletions(-)
+
+diff --git a/src/gui/painting/qcoregraphics.mm b/src/gui/painting/qcoregraphics.mm
+index 98fdd7f..c4fb8af 100644
+--- a/src/gui/painting/qcoregraphics.mm
++++ b/src/gui/painting/qcoregraphics.mm
+@@ -72,17 +72,8 @@ CGImageRef qt_mac_toCGImageMask(const QImage &image)
+                               image.bytesPerLine(), dataProvider, NULL, false);
+ }
+ 
+-OSStatus qt_mac_drawCGImage(CGContextRef inContext, const CGRect *inBounds, CGImageRef inImage)
++void qt_mac_drawCGImage(CGContextRef inContext, const CGRect *inBounds, CGImageRef inImage)
+ {
+-    // Verbatim copy if HIViewDrawCGImage (as shown on Carbon-Dev)
+-    OSStatus err = noErr;
+-
+-#ifdef Q_OS_MACOS
+-    require_action(inContext != NULL, InvalidContext, err = paramErr);
+-    require_action(inBounds != NULL, InvalidBounds, err = paramErr);
+-    require_action(inImage != NULL, InvalidImage, err = paramErr);
+-#endif
+-
+     CGContextSaveGState( inContext );
+     CGContextTranslateCTM (inContext, 0, inBounds->origin.y + CGRectGetMaxY(*inBounds));
+     CGContextScaleCTM(inContext, 1, -1);
+@@ -90,13 +81,6 @@ OSStatus qt_mac_drawCGImage(CGContextRef inContext, const CGRect *inBounds, CGIm
+     CGContextDrawImage(inContext, *inBounds, inImage);
+ 
+     CGContextRestoreGState(inContext);
+-
+-#ifdef Q_OS_MACOS
+-InvalidImage:
+-InvalidBounds:
+-InvalidContext:
+-#endif
+-    return err;
+ }
+ 
+ QImage qt_mac_toQImage(CGImageRef image)
+diff --git a/src/gui/painting/qcoregraphics_p.h b/src/gui/painting/qcoregraphics_p.h
+index 54de3f3..d74c4d0 100644
+--- a/src/gui/painting/qcoregraphics_p.h
++++ b/src/gui/painting/qcoregraphics_p.h
+@@ -71,7 +71,7 @@ Q_GUI_EXPORT CGImageRef qt_mac_toCGImage(const QImage &qImage);
+ Q_GUI_EXPORT CGImageRef qt_mac_toCGImageMask(const QImage &qImage);
+ Q_GUI_EXPORT QImage qt_mac_toQImage(CGImageRef image);
+ 
+-Q_GUI_EXPORT OSStatus qt_mac_drawCGImage(CGContextRef inContext, const CGRect *inBounds, CGImageRef inImage);
++Q_GUI_EXPORT void qt_mac_drawCGImage(CGContextRef inContext, const CGRect *inBounds, CGImageRef inImage);
+ 
+ Q_GUI_EXPORT CGColorSpaceRef qt_mac_genericColorSpace();
+ Q_GUI_EXPORT CGColorSpaceRef qt_mac_colorSpaceForDeviceType(const QPaintDevice *paintDevice);
+-- 
+2.7.4
+

--- a/prepare_osx_build_environment.sh
+++ b/prepare_osx_build_environment.sh
@@ -44,7 +44,7 @@ do
         echo "  -p or --path build-path"
         echo "     folder where the dependencies should be built; default ~/cmake_builds"
         echo "  -q or --qt qt-version:"
-        echo "     Specific version of Qt to build; default 5.8.0 "
+        echo "     Specific version of Qt to build; default $QT_VER "
         echo "  -r or --rebuild:"
         echo "     Rebuild even if dependency is already built"
         echo " "
@@ -64,10 +64,16 @@ QT_MINOR="${qt_ver_parts[0]}.${qt_ver_parts[1]}"
 
 QT_PATH=${BUILD_PATH}/Qt-${QT_VER}-OpenSSL
 
+
 GREY='\033[0;37m'
 ORANGE='\033[0;33m'
 RED='\033[0;31m'
 RESET='\033[0m'
+
+realpath() {
+    [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+SCRIPT_PATH=$(dirname $(realpath "$0") )
 
 
 if [[ "$REBUILD" = true || ! -d ${QT_PATH} ]] ; then
@@ -76,6 +82,11 @@ if [[ "$REBUILD" = true || ! -d ${QT_PATH} ]] ; then
     curl -O -L http://download.qt.io/official_releases/qt/${QT_MINOR}/${QT_VER}/submodules/qtbase-opensource-src-${QT_VER}.tar.xz
     tar xf qtbase-opensource-src-${QT_VER}.tar.xz
     cd qtbase-opensource-src-${QT_VER}
+    CLANG_MAJOR_VER=$(clang --version | grep LLVM | egrep -o "version ([0-9]{1}\.)" | cut -d ' ' -f 2)
+    if [[ "$QT_VER" = "5.9.1" && "$CLANG_MAJOR_VER" = "9." ]] ; then
+        patch -Np1 -i $SCRIPT_PATH/patches/qt-5.9.1-xcode-9.patch
+    fi
+    read -n1 -r -p "Press any key to continue..." key
     ./configure -prefix ${QT_PATH} -opensource -nomake tests -nomake examples -no-securetransport -openssl-linked -confirm-license -I /usr/local/opt/openssl/include -L /usr/local/opt/openssl/lib
     make
     make install


### PR DESCRIPTION
Correct hover/pressed styles and svg icons applied to:
- Page navigation buttons
- Main (Ok, unblock sign etc) button
- Cancel buttons
- Container navigation buttons
- Light (change pin etc) buttons
- card info box
- Action icons (download/remove)
- Toolbar buttons

Fix for macOS Qt build script on xcode 9 compiler

Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>