### PR TITLE
Use cached Qt with OpenSSL backend for osx Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,10 +70,10 @@ deploy:
   access_key_id: $AWS_ACCESS_KEY_ID
   secret_access_key: $AWS_SECRET_ACCESS_KEY
   region: $AWS_REGION
-  bucket: "arn:aws:s3:::open-eid-digidoc4"
+  bucket: "arn:aws:s3:::digidoc4-builds"
   skip_cleanup: true
   local_dir: build/${TARGET}/$BUILD_NUMBER
-  upload-dir: travis-builds
+  upload-dir: ${TARGET}
   acl: public_read
   on:
     branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,9 @@ before_install:
 script: case ${TARGET} in
   *osx*)
     QT_DIR=$(ls -d $HOME/cmake_builds/Qt-*-OpenSSL | tail -n 1);
-    echo "Qt - $QT_DIR";
+    echo "Qt - ${QT_DIR}";
     set -e;
-    mkdir build && cd build && cmake -DQt5_DIR=$QT_DIR/lib/cmake/Qt5 -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DCMAKE_EXE_LINKER_FLAGS="-F/Library/Frameworks" ..;
+    mkdir build && cd build && cmake -DQt5_DIR=${QT_DIR}/lib/cmake/Qt5 -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DCMAKE_EXE_LINKER_FLAGS="-F/Library/Frameworks" ..;
     mkdir -p ${TARGET}/$BUILD_NUMBER;
     make zipdebug macdeployqt zip && cp qdigidoc4*.zip ${TARGET}/$BUILD_NUMBER/ && cd ..;
     ;;

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,29 +24,23 @@ before_install:
     sudo installer -verboseR -pkg libdigidoc.pkg -target /;
     sudo installer -verboseR -pkg libdigidocpp.pkg -target /;
     sudo installer -verboseR -pkg esteid-pkcs11.pkg -target /;
-    if ls ~/cmake_builds/Qt-*-OpenSSL 1> /dev/null 2>&1; then
-      echo "QT already installed";
+    HASH=($(shasum prepare_osx_build_environment.sh | cut -d ' ' -f 1));
+    pip install --user awscli > /dev/null;
+    export PATH=$PATH:`echo ~/Library/Python/*/bin` ;
+    aws s3 cp s3://open-eid-digidoc4/cache/${TARGET}/${HASH}.zip ${HASH}.zip --no-sign-request;
+    if [ $? -eq 0 ]; then
+      unzip -qq -d /tmp ${HASH}.zip;
     else
-      echo "QT not installed";
-      HASH=($(shasum prepare_osx_build_environment.sh | cut -d ' ' -f 1));
-      pip install --user awscli > /dev/null;
-      export PATH=$PATH:`echo ~/Library/Python/*/bin` ;
-      aws s3 cp s3://open-eid-digidoc4/cache/${TARGET}/${HASH}.zip ${HASH}.zip --no-sign-request;
-      if [ $? -eq 0 ]; then
-        mkdir -p $HOME/cmake_builds;
-        unzip -qq -d $HOME/cmake_builds ${HASH}.zip;
-      else
-        ./prepare_osx_build_environment.sh > /dev/null;
-        if [ ${AWS_ACCESS_KEY_ID:+1} ]; then
-          cd ~/cmake_builds && zip -q -r $OLDPWD/${HASH}.zip Qt-*-OpenSSL && cd $OLDPWD;
-          aws s3 cp ${HASH}.zip s3://open-eid-digidoc4/cache/${TARGET}/${HASH}.zip --acl public-read;
-        fi
+      ./prepare_osx_build_environment.sh -p /tmp > /dev/null;
+      if [ ${AWS_ACCESS_KEY_ID:+1} ]; then
+        cd /tmp && zip -q -r $OLDPWD/${HASH}.zip Qt-*-OpenSSL && cd $OLDPWD;
+        aws s3 cp ${HASH}.zip s3://open-eid-digidoc4/cache/${TARGET}/${HASH}.zip --acl public-read;
       fi
     fi
   fi
 script: case ${TARGET} in
   *osx*)
-    QT_DIR=$(ls -d $HOME/cmake_builds/Qt-*-OpenSSL | tail -n 1);
+    QT_DIR=$(ls -d /tmp/Qt-*-OpenSSL | tail -n 1);
     echo "Qt - ${QT_DIR}";
     set -e;
     mkdir build && cd build && cmake -DQt5_DIR=${QT_DIR}/lib/cmake/Qt5 -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DCMAKE_EXE_LINKER_FLAGS="-F/Library/Frameworks" ..;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-# TODO: Use S3 cache to download osx dependencies
----
 language: c++
 sudo: true
 dist: trusty
@@ -19,19 +17,41 @@ env:
   - BUILD_NUMBER=${TRAVIS_BUILD_NUMBER}
 before_install: 
 - git submodule update --init --recursive && if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
-    brew install --force qt5 openssl;
+    brew install --force openssl;
     curl -s --location "https://github.com/open-eid/libdigidoc/releases/download/v3.10.3/libdigidoc_3.10.3.1214.pkg" -o libdigidoc.pkg;
     curl -s --location "https://github.com/open-eid/libdigidocpp/releases/download/v3.13.1/libdigidocpp_3.13.1.1353.pkg" -o libdigidocpp.pkg;
     curl -s --location "https://github.com/open-eid/esteid-pkcs11/releases/download/v3.10.1/esteid-pkcs11_3.10.1.64.pkg" -o esteid-pkcs11.pkg;
     sudo installer -verboseR -pkg libdigidoc.pkg -target /;
     sudo installer -verboseR -pkg libdigidocpp.pkg -target /;
     sudo installer -verboseR -pkg esteid-pkcs11.pkg -target /;
+    if ls ~/cmake_builds/Qt-*-OpenSSL 1> /dev/null 2>&1; then
+      echo "QT already installed";
+    else
+      echo "QT not installed";
+      HASH=($(shasum prepare_osx_build_environment.sh | cut -d ' ' -f 1));
+      pip install --user awscli > /dev/null;
+      export PATH=$PATH:`echo ~/Library/Python/*/bin` ;
+      aws s3 cp s3://open-eid-digidoc4/cache/${TARGET}/${HASH}.zip ${HASH}.zip --no-sign-request;
+      if [ $? -eq 0 ]; then
+        mkdir -p $HOME/cmake_builds;
+        unzip -qq -d $HOME/cmake_builds ${HASH}.zip;
+      else
+        ./prepare_osx_build_environment.sh > /dev/null;
+        if [ ${AWS_ACCESS_KEY_ID:+1} ]; then
+          cd ~/cmake_builds && zip -q -r $OLDPWD/${HASH}.zip Qt-*-OpenSSL && cd $OLDPWD;
+          aws s3 cp ${HASH}.zip s3://open-eid-digidoc4/cache/${TARGET}/${HASH}.zip --acl public-read;
+        fi
+      fi
+    fi
   fi
 script: case ${TARGET} in
   *osx*)
+    QT_DIR=$(ls -d $HOME/cmake_builds/Qt-*-OpenSSL | tail -n 1);
+    echo "Qt - $QT_DIR";
     set -e;
-    mkdir build && cd build && cmake -DQt5_DIR=/usr/local/opt/qt5/lib/cmake/Qt5 -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DCMAKE_EXE_LINKER_FLAGS="-F/Library/Frameworks" ..;
-    make zipdebug macdeployqt zip && cd ..;
+    mkdir build && cd build && cmake -DQt5_DIR=$QT_DIR/lib/cmake/Qt5 -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DCMAKE_EXE_LINKER_FLAGS="-F/Library/Frameworks" ..;
+    mkdir -p ${TARGET}/$BUILD_NUMBER;
+    make zipdebug macdeployqt zip && cp qdigidoc4*.zip ${TARGET}/$BUILD_NUMBER/ && cd ..;
     ;;
   *)
     docker run -e BUILD_NUMBER=${TRAVIS_BUILD_NUMBER} -e DEBFULLNAME="Travis" -e DEBEMAIL="travis-ci@travis" -e IMAGE=${TARGET} -v $(pwd):$(pwd) -t "${TARGET}" /bin/bash -c "cd $(pwd);"'
@@ -47,5 +67,19 @@ script: case ${TARGET} in
       dh_make --createorig --addmissing --defaultless -y -p qdigidoc4_${VERSION};
       dch --distribution $(lsb_release -cs) -v ${VERSION} "Release ${VERSION}.";
       dpkg-buildpackage -rfakeroot -us -uc;
+      mkdir -p build/${TARGET}/$BUILD_NUMBER;
+      cp ../qdigidoc4_*.deb build/${TARGET}/$BUILD_NUMBER;
       git clean -dxf';
   esac
+deploy:
+  provider: s3
+  access_key_id: $AWS_ACCESS_KEY_ID
+  secret_access_key: $AWS_SECRET_ACCESS_KEY
+  region: $AWS_REGION
+  bucket: "arn:aws:s3:::open-eid-digidoc4"
+  skip_cleanup: true
+  local_dir: build/${TARGET}/$BUILD_NUMBER
+  upload-dir: travis-builds
+  acl: public_read
+  on:
+    branch: master

--- a/prepare_osx_build_environment.sh
+++ b/prepare_osx_build_environment.sh
@@ -86,7 +86,6 @@ if [[ "$REBUILD" = true || ! -d ${QT_PATH} ]] ; then
     if [[ "$QT_VER" = "5.9.1" && "$CLANG_MAJOR_VER" = "9." ]] ; then
         patch -Np1 -i $SCRIPT_PATH/patches/qt-5.9.1-xcode-9.patch
     fi
-    read -n1 -r -p "Press any key to continue..." key
     ./configure -prefix ${QT_PATH} -opensource -nomake tests -nomake examples -no-securetransport -openssl-linked -confirm-license -I /usr/local/opt/openssl/include -L /usr/local/opt/openssl/lib
     make
     make install


### PR DESCRIPTION
- Download osx QT from S3 cache instead of using Homebrew
- Deploy built artifacts to S3

Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>