### PR TITLE
Show Other EID (Mobile, Digi, Other)

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -16,8 +16,9 @@ configure_file( translations/tr.qrc tr.qrc COPYONLY )
 qt5_add_translation( SOURCES translations/en.ts translations/et.ts translations/ru.ts )
 qt5_add_resources( SOURCES images/images.qrc fonts/fonts.qrc ${CMAKE_CURRENT_BINARY_DIR}/tr.qrc ${CMAKE_CURRENT_BINARY_DIR}/TSL.qrc )
 qt5_wrap_ui( SOURCES MainWindow.ui dialogs/AddRecipients.ui dialogs/CertificateDetails.ui dialogs/FirstRun.ui dialogs/PinPopup.ui dialogs/PinUnblock.ui dialogs/SettingsDialog.ui
-					widgets/Accordion.ui widgets/AccordionTitle.ui widgets/AddressItem.ui widgets/CardWidget.ui widgets/ContainerPage.ui widgets/FileItem.ui widgets/InfoStack.ui
-					widgets/ItemList.ui widgets/MainAction.ui dialogs/MobileDialog.ui widgets/NoCardInfo.ui widgets/OtherData.ui widgets/PageIcon.ui widgets/SignatureItem.ui widgets/VerifyCert.ui )
+		widgets/Accordion.ui widgets/AccordionTitle.ui widgets/AddressItem.ui widgets/CardWidget.ui widgets/ContainerPage.ui widgets/FileItem.ui widgets/InfoStack.ui
+		widgets/ItemList.ui widgets/MainAction.ui dialogs/MobileDialog.ui widgets/NoCardInfo.ui widgets/OtherData.ui widgets/PageIcon.ui widgets/SignatureItem.ui widgets/VerifyCert.ui
+		widgets/OtherId.ui widgets/NoOtherId.ui )
 
 if( APPLE )
 	list( APPEND SOURCES Application_mac.mm )
@@ -75,6 +76,8 @@ add_executable( ${PROGNAME} WIN32 MACOSX_BUNDLE
 	widgets/SignatureItem.cpp
 	widgets/StyledWidget.cpp
 	widgets/VerifyCert.cpp
+	widgets/OtherId.cpp
+	widgets/NoOtherId.cpp
 	)
 add_manifest( ${PROGNAME} )
 target_link_libraries( ${PROGNAME}

--- a/client/MainWindow.cpp
+++ b/client/MainWindow.cpp
@@ -128,6 +128,7 @@ MainWindow::MainWindow( QWidget *parent ) :
 	connect( ui->infoStack, &InfoStack::photoClicked, this, &MainWindow::photoClicked );
 	connect( ui->cardInfo, &CardWidget::photoClicked, this, &MainWindow::photoClicked );   // To load photo
 	connect( ui->cardInfo, &CardWidget::selected, this, [this]() { if( selector ) selector->press(); } );
+	connect( ui->accordion, &Accordion::checkOtherEID, this, &MainWindow::getOtherEID );
 
 	showCardStatus();
 	connect( ui->accordion, SIGNAL( changePin1Clicked( bool, bool ) ), this, SLOT( changePin1Clicked( bool, bool ) ) );
@@ -258,10 +259,10 @@ void MainWindow::hideWarningArea()
 	ui->warning->hide();
 }
 
-// Mouse click on warning region will hide it.
+// Any mouse click inside application will hide it.
 void MainWindow::mousePressEvent(QMouseEvent *event)
 {
-	if(ui->warning->underMouse())
+//	if(ui->warning->underMouse() ) // Mouse click on warning region will hide it.
 		hideWarningArea();
 }
 
@@ -496,9 +497,11 @@ void MainWindow::noReader_NoCard_Loading_Event( const QString &text, bool isLoad
 	ui->infoStack->clearPicture();
 	ui->infoStack->hide();
 	ui->accordion->hide();
-	ui->accordion->updateOtherData( false );
+	ui->accordion->updateOtherData( false );    // E-mail
 	ui->myEid->invalidCertIcon( false );
 	ui->myEid->pinIsBlockedIcon( false );
+	ui->accordion->clearOtherEID();
+	hideWarningArea();
 }
 
 // Loads picture 

--- a/client/MainWindow.h
+++ b/client/MainWindow.h
@@ -59,6 +59,7 @@ private Q_SLOTS:
 	void changePin2Clicked( bool isForgotPin, bool isBlockedPin );
 	void changePukClicked( bool isForgotPuk );
 	void certDetailsClicked( const QString &link );
+	void getOtherEID ();
 
 protected:
 	void dragEnterEvent( QDragEnterEvent *event ) override;
@@ -127,6 +128,8 @@ private:
 	QByteArray sendRequest( SSLConnect::RequestType type, const QString &param = QString() );
 	void pinUnblock( QSmartCardData::PinType type, bool isForgotPin = false );
 	void pinPukChange( QSmartCardData::PinType type );
+	void getMobileIdStatus ();
+	void getDigiIdStatus ();
 
 	Ui::MainWindow *ui;
 

--- a/client/MainWindow_MyEID.cpp
+++ b/client/MainWindow_MyEID.cpp
@@ -255,3 +255,34 @@ void MainWindow::showNotification( const QString &msg, bool isSuccess )
 	FadeInNotification* notification = new FadeInNotification( this, textColor, bkColor, 110 );
 	notification->start( msg, 750, 2500, 600 );
 }
+
+void MainWindow::getOtherEID ()
+{
+	getMobileIdStatus ();
+	getDigiIdStatus ();
+}
+
+void MainWindow::getMobileIdStatus ()
+{
+	QByteArray buffer = sendRequest( SSLConnect::MobileInfo );
+	if( buffer.isEmpty() )
+		return;
+
+	XmlReader xml( buffer );
+	int error = 0;
+	QVariant mobileData = QVariant::fromValue( xml.readMobileStatus( error ) );
+	if( error )
+	{
+		showWarning( XmlReader::mobileErr( error ), QString() );
+		return;
+	}
+	ui->accordion->setProperty( "MOBILE_ID_STATUS", mobileData );
+	ui->accordion->updateMobileIdInfo();
+}
+
+void MainWindow::getDigiIdStatus ()
+{
+	// TODO
+	ui->accordion->setProperty( "DIGI_ID_STATUS", QVariant() );
+	ui->accordion->updateDigiIdInfo();
+}

--- a/client/sslConnect.cpp
+++ b/client/sslConnect.cpp
@@ -27,6 +27,8 @@
 #include <QtCore/QJsonObject>
 #include <QtWidgets/QProgressBar>
 #include <QtWidgets/QProgressDialog>
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QHBoxLayout>
 
 QByteArray HTTPRequest::request() const
 {
@@ -168,12 +170,17 @@ QByteArray SSLConnect::getUrl( RequestType type, const QString &value )
 		return QByteArray();
 	}
 
+//	Does not align it to center on Unix
+    QFrame popup (qApp->activeWindow(), Qt::Tool | Qt::Window | Qt::FramelessWindowHint);
+
+    showPopup( popup, label );
+/*
 	QProgressDialog p( label, QString(), 0, 0, qApp->activeWindow() );
 	p.setWindowFlags( (p.windowFlags() | Qt::CustomizeWindowHint) & ~Qt::WindowCloseButtonHint );
 	if( QProgressBar *bar = p.findChild<QProgressBar*>() )
 		bar->setTextVisible( false );
 	p.open();
-
+*/
 	QEventLoop e;
 	connect( d, SIGNAL(finished()), &e, SLOT(quit()) );
 	d->start();
@@ -219,4 +226,22 @@ void SSLConnect::setToken( const QSslCertificate &cert, Qt::HANDLE key )
 		!SSL_use_PrivateKey( d->ssl, (EVP_PKEY*)key ) ||
 		!SSL_check_private_key( d->ssl ) )
 		d->setError();
+}
+
+void SSLConnect::showPopup( QFrame &popup, const QString &labelText )
+{
+	popup.resize( 328, 179 );
+	popup.setStyleSheet( "background-color: #e8e8e8; border: solid #5e5e5e; border-width: 1px 1px 1px 1px;" );
+
+	QLabel *lbl = new QLabel( &popup );
+	lbl->setStyleSheet( QString( "font-size: 24px; color: #53c964; border: none;" ) );
+	lbl->setAlignment( Qt::AlignHCenter | Qt::AlignVCenter );
+	lbl->setText( labelText );
+	lbl->show();
+
+	QHBoxLayout* layout=new QHBoxLayout ( &popup );
+	layout->addWidget( lbl );
+	popup.setLayout( layout );
+
+	popup.show();
 }

--- a/client/widgets/Accordion.cpp
+++ b/client/widgets/Accordion.cpp
@@ -20,6 +20,10 @@
 #include "Accordion.h"
 #include "ui_Accordion.h"
 
+#include "XmlReader.h"
+
+Q_DECLARE_METATYPE(MobileStatus)
+
 Accordion::Accordion( QWidget *parent ) :
 	StyledWidget( parent ),
 	ui( new Ui::Accordion ),
@@ -51,17 +55,20 @@ void Accordion::init()
 
 	connect(ui->authBox, SIGNAL( certDetailsClicked( QString ) ), this, SLOT( certDetails( QString ) ) );
 	connect(ui->signBox, SIGNAL( certDetailsClicked( QString ) ), this, SLOT( certDetails( QString ) ) );
-
+    
 	// Initialize PIN/PUK content widgets.
 	ui->signBox->addBorders();
 
 	ui->contentOtherData->update( false );
+    clearOtherEID();
 }
 
 void Accordion::closeOtherSection( AccordionTitle* opened )
 {
 	openSection->closeSection();
 	openSection = opened;
+
+	idCheckOtherEIdNeeded( opened );
 }
 
 void Accordion::updateOtherData( bool activate, const QString &eMail, const quint8 &errorCode )
@@ -84,6 +91,8 @@ void Accordion::updateInfo( const QSmartCard *smartCard )
 	ui->authBox->update( QSmartCardData::Pin1Type, smartCard );
 	ui->signBox->update( QSmartCardData::Pin2Type, smartCard );
 	ui->pukBox->update( QSmartCardData::PukType, smartCard );
+
+	ui->otherID->update( "Teised eID-d");
 }
 
 void Accordion::changePin1( bool isForgotPin, bool isBlockedPin )
@@ -104,4 +113,48 @@ void Accordion::changePuk( bool isForgotPuk, bool isBlockedPin )
 void Accordion::certDetails( const QString &link )
 {
 	emit certDetailsClicked ( link );
+}
+
+void Accordion::clearOtherEID()
+{
+	// Set to default Certificate Info page
+	closeOtherSection( ui->titleVerifyCert );
+    ui->titleVerifyCert->openSection();
+
+	ui->mobID->hide();
+	ui->digiID->hide();
+
+	setProperty( "MOBILE_ID_STATUS", QVariant() );
+}
+
+void Accordion::updateMobileIdInfo()
+{
+	MobileStatus mobile = property("MOBILE_ID_STATUS").value<MobileStatus>();
+	ui->mobID->updateMobileId(
+		mobile.value( "MSISDN" ),
+		mobile.value( "Operator" ),
+		mobile.value( "Status" ),
+		mobile.value( "MIDCertsValidTo" ) );
+
+	ui->mobID->show();
+}
+
+void Accordion::updateDigiIdInfo()
+{
+	QVariant digiIdData = property("DIGI_ID_STATUS").value<QVariant>();
+
+	ui->digiID->updateDigiId(
+		"PA789456123",
+		"01.01.2022",
+		"Activ",
+		"07.08.2022, 20:59:59" );
+
+	ui->digiID->show();
+}
+
+void Accordion::idCheckOtherEIdNeeded( AccordionTitle* opened )
+{
+	// If user has not validated (entering valid PIN1) the EID status yet.
+	if ( property("MOBILE_ID_STATUS").isNull() && opened == ui->titleOtherEID )
+		emit checkOtherEID ();
 }

--- a/client/widgets/Accordion.h
+++ b/client/widgets/Accordion.h
@@ -42,6 +42,10 @@ public:
 	QString getEmail();
 	void setFocusToEmail();
 	void updateInfo( const QSmartCard *smartCard );
+	void clearOtherEID();
+	void updateMobileIdInfo();
+	void updateDigiIdInfo();
+	void idCheckOtherEIdNeeded( AccordionTitle* opened );
 
 private Q_SLOTS:
   	void changePin1( bool isForgotPin, bool isBlockedPin );
@@ -56,6 +60,7 @@ signals:
 	void changePin2Clicked( bool isForgotPin, bool isBlockedPin );
 	void changePukClicked( bool isForgotPuk );
 	void certDetailsClicked( const QString &link );
+	void checkOtherEID();
 
 private:
 	Ui::Accordion *ui;

--- a/client/widgets/Accordion.ui
+++ b/client/widgets/Accordion.ui
@@ -167,6 +167,62 @@
      <property name="styleSheet">
       <string notr="true">background-color: white;</string>
      </property>
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QWidget" name="widgetOther" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <property name="spacing">
+          <number>1</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="OtherId" name="mobID" native="true"/>
+         </item>
+         <item>
+          <widget class="OtherId" name="digiID" native="true">
+           <zorder>mobID</zorder>
+          </widget>
+         </item>
+         <item>
+          <widget class="NoOtherId" name="otherID" native="true">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>
@@ -188,6 +244,18 @@
    <class>OtherData</class>
    <extends>QWidget</extends>
    <header>widgets/OtherData.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>OtherId</class>
+   <extends>QWidget</extends>
+   <header>widgets/OtherId.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>NoOtherId</class>
+   <extends>QWidget</extends>
+   <header>widgets/NoOtherId.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/client/widgets/AccordionTitle.cpp
+++ b/client/widgets/AccordionTitle.cpp
@@ -83,4 +83,8 @@ void AccordionTitle::mouseReleaseEvent(QMouseEvent *event)
 		accordion->closeOtherSection(this);
 		openSection();
 	}
+	else
+	{
+		accordion->idCheckOtherEIdNeeded( this );
+	}
 }

--- a/client/widgets/NoOtherId.cpp
+++ b/client/widgets/NoOtherId.cpp
@@ -1,0 +1,56 @@
+/*
+ * QDigiDoc4
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include "NoOtherId.h"
+#include "ui_NoOtherId.h"
+#include "Styles.h"
+
+NoOtherId::NoOtherId( QWidget *parent ) :
+	StyledWidget( parent ),
+    ui( new Ui::NoOtherId )
+{
+	ui->setupUi(this);
+
+	QFont font14 = Styles::font( Styles::Regular, 14 );
+	QFont font18 = Styles::font( Styles::Regular, 18 );
+	
+	ui->lblName->setFont( font18 );
+	ui->lblInfo->setFont( font14 );
+	ui->lblMobileID->setFont( font14 );
+	ui->lblDigiID->setFont( font14 );
+	ui->lblSmartID->setFont( font14 );
+
+	// top | right | bottom | left
+	this->setStyleSheet( "background-color: #ffffff; border: solid #DFE5E9; border-width: 1px 0px 0px 1px;" );
+}
+
+NoOtherId::~NoOtherId()
+{
+    delete ui;
+}
+
+void NoOtherId::update( const QString &lblName )
+{
+	ui->lblName->setText( lblName );
+    QString decoration = "style='color: #006EB5; text-decoration: none;'";
+
+	ui->lblMobileID->setText( "<a href='http://mobiil.id.ee'><span " + decoration + ">Mobiili-ID</span></a>" );
+	ui->lblDigiID->setText( "<a href='https://www.id.ee/?lang=et&id=34178/'><span " + decoration + ">Digi-ID</span></a>" );
+	ui->lblSmartID->setText( "<a href='https://www.smart-id.com/et/'><span " + decoration + ">SmartID</span></a>" );
+}

--- a/client/widgets/NoOtherId.h
+++ b/client/widgets/NoOtherId.h
@@ -1,5 +1,5 @@
 /*
- * QEstEidUtil
+ * QDigiDoc4
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -19,32 +19,22 @@
 
 #pragma once
 
-#include <QtCore/QObject>
+#include "widgets/StyledWidget.h"
 
-class QSslCertificate;
-class QFrame;
+namespace Ui {
+class NoOtherId;
+}
 
-class SSLConnectPrivate;
-class SSLConnect: public QObject
+class NoOtherId : public StyledWidget
 {
-	Q_OBJECT
+    Q_OBJECT
 
 public:
-	enum RequestType {
-		EmailInfo,
-		ActivateEmails,
-		MobileInfo,
-		PictureInfo
-	};
+    explicit NoOtherId( QWidget *parent = nullptr );
+    ~NoOtherId();
 
-	explicit SSLConnect( QObject *parent = 0 );
-	~SSLConnect();
-
-	QString errorString() const;
-	QByteArray getUrl( RequestType type, const QString &value = QString() );
-	void setToken( const QSslCertificate &cert, Qt::HANDLE key );
-	void showPopup( QFrame &popup, const QString &labelText );
-
+	void update( const QString &lblName = "" );
+    
 private:
-	SSLConnectPrivate	*d;
+    Ui::NoOtherId *ui;
 };

--- a/client/widgets/NoOtherId.ui
+++ b/client/widgets/NoOtherId.ui
@@ -1,0 +1,309 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>NoOtherId</class>
+ <widget class="QWidget" name="NoOtherId">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>305</width>
+    <height>220</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>305</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string/>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_3">
+   <property name="spacing">
+    <number>2</number>
+   </property>
+   <property name="leftMargin">
+    <number>10</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>10</number>
+   </property>
+   <property name="bottomMargin">
+    <number>2</number>
+   </property>
+   <item>
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Expanding</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>1</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QWidget" name="widget" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>100</height>
+      </size>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">border: none;</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QLabel" name="lblName">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>21</height>
+         </size>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">border: none; color: #041E42; font-size: 18px; 	font-weight: 500;</string>
+        </property>
+        <property name="lineWidth">
+         <number>1</number>
+        </property>
+        <property name="text">
+         <string>Other ID</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="verticalSpacer_3">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>5</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QLabel" name="lblInfo">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">color: #353739; line-height: 16px;</string>
+        </property>
+        <property name="text">
+         <string>Teil ei ole teisi eID-sid.
+Rohkem infot leiate siit:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="verticalSpacer_5">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>3</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <layout class="QVBoxLayout" name="verticalLayout">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="lblMobileID">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">color: #006EB5;  line-height: 16px;</string>
+          </property>
+          <property name="text">
+           <string>&lt;a href='http://mobiil.id.ee'&gt;Mobiili-ID&lt;/a&gt;
+</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="openExternalLinks">
+           <bool>true</bool>
+          </property>
+          <property name="textInteractionFlags">
+           <set>Qt::TextBrowserInteraction</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="lblDigiID">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">color: #006EB5;  line-height: 16px;</string>
+          </property>
+          <property name="text">
+           <string>&lt;a href=&quot;https://www.id.ee/?lang=et&amp;id=34178/&quot;&gt;Digi-ID&lt;/a&gt;</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="openExternalLinks">
+           <bool>true</bool>
+          </property>
+          <property name="textInteractionFlags">
+           <set>Qt::TextBrowserInteraction</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="lblSmartID">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">color: #006EB5; line-height: 16px;</string>
+          </property>
+          <property name="text">
+           <string>&lt;a href=&quot;https://www.smart-id.com/et/&quot;&gt;SmartID&lt;/a&gt;</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="openExternalLinks">
+           <bool>true</bool>
+          </property>
+          <property name="textInteractionFlags">
+           <set>Qt::TextBrowserInteraction</set>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <spacer name="verticalSpacer_4">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QWidget" name="widgetDummy" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_4">
+         <item>
+          <widget class="QLabel" name="lblDummy">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <spacer name="verticalSpacer_6">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>1</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Expanding</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/client/widgets/NoOtherId.ui
+++ b/client/widgets/NoOtherId.ui
@@ -33,7 +33,7 @@
     <number>10</number>
    </property>
    <property name="topMargin">
-    <number>0</number>
+    <number>2</number>
    </property>
    <property name="rightMargin">
     <number>10</number>
@@ -51,8 +51,8 @@
      </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>1</width>
-       <height>0</height>
+       <width>20</width>
+       <height>2</height>
       </size>
      </property>
     </spacer>
@@ -62,7 +62,13 @@
      <property name="minimumSize">
       <size>
        <width>0</width>
-       <height>100</height>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>160</height>
       </size>
      </property>
      <property name="styleSheet">
@@ -93,7 +99,7 @@
          <string>Other ID</string>
         </property>
         <property name="alignment">
-         <set>Qt::AlignCenter</set>
+         <set>Qt::AlignHCenter|Qt::AlignTop</set>
         </property>
        </widget>
       </item>
@@ -165,6 +171,12 @@ Rohkem infot leiate siit:</string>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>16</height>
+           </size>
+          </property>
           <property name="styleSheet">
            <string notr="true">color: #006EB5;  line-height: 16px;</string>
           </property>
@@ -191,6 +203,12 @@ Rohkem infot leiate siit:</string>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>16</height>
+           </size>
+          </property>
           <property name="styleSheet">
            <string notr="true">color: #006EB5;  line-height: 16px;</string>
           </property>
@@ -216,6 +234,12 @@ Rohkem infot leiate siit:</string>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>16</height>
+           </size>
+          </property>
           <property name="styleSheet">
            <string notr="true">color: #006EB5; line-height: 16px;</string>
           </property>
@@ -235,54 +259,6 @@ Rohkem infot leiate siit:</string>
         </item>
        </layout>
       </item>
-      <item>
-       <spacer name="verticalSpacer_4">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::Fixed</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QWidget" name="widgetDummy" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout_4">
-         <item>
-          <widget class="QLabel" name="lblDummy">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item>
-       <spacer name="verticalSpacer_6">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>1</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
      </layout>
     </widget>
    </item>
@@ -296,8 +272,8 @@ Rohkem infot leiate siit:</string>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>0</width>
-       <height>0</height>
+       <width>20</width>
+       <height>80</height>
       </size>
      </property>
     </spacer>

--- a/client/widgets/OtherData.cpp
+++ b/client/widgets/OtherData.cpp
@@ -38,6 +38,9 @@ OtherData::OtherData(QWidget *parent) :
 	ui->lblEMail->setFont( font );
 	ui->lblNoForwarding->setFont( font );
 	ui->labelEestiEe->setFont( Styles::font( Styles::Regular, 12 ) );
+    QString decoration = "style='color: #006EB5;  text-decoration: none; font-weight: 900;'";
+	ui->labelEestiEe->setText( "Täiuslikuma ametliku e-posti häälestamisvahendi leiad portaalist <a href='www.eesti.ee'><span " + decoration + ">eesti.ee</span></a>" );
+    ui->labelEestiEe->setOpenExternalLinks( true );	
 	ui->activate->setFont( condensed );
 	ui->btnCheckEMail->setFont( condensed );
 	ui->activate->setStyleSheet(

--- a/client/widgets/OtherId.cpp
+++ b/client/widgets/OtherId.cpp
@@ -1,0 +1,118 @@
+/*
+ * QDigiDoc4
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include "OtherId.h"
+#include "ui_OtherId.h"
+#include "Styles.h"
+
+#include "XmlReader.h"
+
+#include <QtCore/QTextStream>
+
+OtherId::OtherId( QWidget *parent ) :
+	StyledWidget( parent ),
+	ui( new Ui::OtherId )
+{
+	ui->setupUi( this );
+
+	QFont font11 = Styles::font( Styles::Regular, 11 );
+	QFont font14 = Styles::font( Styles::Regular, 14 );
+	QFont font18 = Styles::font( Styles::Regular, 18 );
+	
+	ui->lblIdName->setFont( font18 );
+	ui->lblLeftHdr->setFont( font11 );
+	ui->lblLeftText->setFont( font14 );
+	ui->lblRightHdr->setFont( font11 );
+	ui->lblRightText->setFont( font14 );
+    ui->lblStatusHdr->setFont( font11 );
+    ui->lblStatusText->setFont( font14 );
+    ui->lblCertHdr->setFont( font11 );
+    ui->lblCertText->setFont( font14 );
+    ui->lblDigiIdInfo->setFont( font11 );
+
+	// top | right | bottom | left
+	this->setStyleSheet( "background-color: #ffffff; border: solid #DFE5E9; border-width: 1px 0px 0px 1px;" );
+}
+
+OtherId::~OtherId()
+{
+	delete ui;
+}
+
+void OtherId::update( const QString &lblIdName )
+{
+	ui->lblIdName->setText( lblIdName );
+}
+
+void OtherId::updateMobileId( const QString &telNumber, const QString &telOperator, const QString &status, const QString &validTill )
+{
+	QString text;
+	QTextStream s( &text );
+
+    ui->lblDigiIdInfo->setText( "" );
+	ui->lblIdName->setText( tr( "Mobiil-ID" ) );
+	ui->lblLeftHdr->setText( tr( "TELEFONI NUMBER" ) );
+	ui->lblLeftText->setText( "+" + telNumber );
+ 	ui->lblRightHdr->setText( tr( "MOBIILI OPERAATOR" ) );
+	ui->lblRightText->setText( telOperator );
+	if( status == "Active" )
+	{
+		s << tr( "Sertifikaadid on " ) << "<span style='color: #8CC368'>"
+			<< tr( "aktiivsed" ) << "</span>"
+			<< tr( " ja Mobiil-ID kasutamine on " ) << "<span style='color: #8CC368'>"
+			<< tr( "võimalik" ) << "</span>";
+
+		ui->lblStatusText->setText( text );
+		ui->lblCertText->setText( "<span style='color: #8CC368'>Kehtivad</span> kuni " + validTill );
+	}
+	else
+	{
+		s << "<span style='color: #e80303'>"
+			<< XmlReader::mobileStatus( status ) << "</span>";
+		ui->lblStatusText->setText( text );
+		ui->lblCertText->setText( "" );
+	}
+}
+
+void OtherId::updateDigiId( const QString &docNumber, const QString &docValid, const QString &status, const QString &validTill )
+{
+	QString text;
+	QTextStream s( &text );
+
+	ui->lblIdName->setText( tr( "Digi-ID" ) );
+	ui->lblLeftText->setText( docNumber );
+	ui->lblRightText->setText( docValid );
+	if( status == "Active" )
+	{
+		s << tr( "Sertifikaadid on " ) << "<span style='color: #8CC368'>"
+			<< tr( "aktiivsed" ) << "</span>"
+			<< tr( " ja Digi-ID kasutamine on " ) << "<span style='color: #8CC368'>"
+			<< tr( "võimalik" ) << "</span>";
+
+		ui->lblStatusText->setText( text );
+		ui->lblCertText->setText( "<span style='color: #8CC368'>Kehtivad</span> kuni " + validTill );
+	}
+	else
+	{
+		s << "<span style='color: #e80303'>"
+			<< "Not implemented!" << "</span>";
+		ui->lblStatusText->setText( text );
+		ui->lblCertText->setText( "" );
+	}
+}

--- a/client/widgets/OtherId.h
+++ b/client/widgets/OtherId.h
@@ -1,5 +1,5 @@
 /*
- * QEstEidUtil
+ * QDigiDoc4
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -19,32 +19,24 @@
 
 #pragma once
 
-#include <QtCore/QObject>
+#include "widgets/StyledWidget.h"
 
-class QSslCertificate;
-class QFrame;
+namespace Ui {
+class OtherId;
+}
 
-class SSLConnectPrivate;
-class SSLConnect: public QObject
+class OtherId : public StyledWidget
 {
 	Q_OBJECT
 
 public:
-	enum RequestType {
-		EmailInfo,
-		ActivateEmails,
-		MobileInfo,
-		PictureInfo
-	};
+	explicit OtherId( QWidget *parent = nullptr );
+	~OtherId();
 
-	explicit SSLConnect( QObject *parent = 0 );
-	~SSLConnect();
-
-	QString errorString() const;
-	QByteArray getUrl( RequestType type, const QString &value = QString() );
-	void setToken( const QSslCertificate &cert, Qt::HANDLE key );
-	void showPopup( QFrame &popup, const QString &labelText );
+	void update( const QString &lblIdName = "" );
+	void updateMobileId( const QString &telNumber, const QString &telOperator, const QString &status, const QString &validTill );
+	void updateDigiId( const QString &docNumber, const QString &docValid, const QString &status, const QString &validTill );
 
 private:
-	SSLConnectPrivate	*d;
+	Ui::OtherId *ui;
 };

--- a/client/widgets/OtherId.ui
+++ b/client/widgets/OtherId.ui
@@ -51,8 +51,8 @@
      </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>1</width>
-       <height>0</height>
+       <width>20</width>
+       <height>2</height>
       </size>
      </property>
     </spacer>
@@ -68,7 +68,7 @@
      <property name="minimumSize">
       <size>
        <width>0</width>
-       <height>100</height>
+       <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
@@ -99,10 +99,10 @@
          <string notr="true">border: none; color: #041E42; font-size: 18px; 	font-weight: 500;</string>
         </property>
         <property name="text">
-         <string>Other ID</string>
+         <string>Mobiil-ID</string>
         </property>
         <property name="alignment">
-         <set>Qt::AlignCenter</set>
+         <set>Qt::AlignHCenter|Qt::AlignTop</set>
         </property>
        </widget>
       </item>
@@ -189,11 +189,20 @@
                  <verstretch>0</verstretch>
                 </sizepolicy>
                </property>
+               <property name="minimumSize">
+                <size>
+                 <width>0</width>
+                 <height>16</height>
+                </size>
+               </property>
                <property name="styleSheet">
                 <string notr="true">color: #75787B; font-size: 11px;</string>
                </property>
                <property name="text">
                 <string>DOKUMENT</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
                </property>
               </widget>
              </item>
@@ -204,6 +213,12 @@
                  <horstretch>0</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>0</width>
+                 <height>0</height>
+                </size>
                </property>
                <property name="styleSheet">
                 <string notr="true">color: #353739; font-size: 14px;</string>
@@ -261,11 +276,20 @@
                  <verstretch>0</verstretch>
                 </sizepolicy>
                </property>
+               <property name="minimumSize">
+                <size>
+                 <width>0</width>
+                 <height>16</height>
+                </size>
+               </property>
                <property name="styleSheet">
                 <string notr="true">color: #75787B; font-size: 11px;</string>
                </property>
                <property name="text">
                 <string>DOKUMENT KEHTIB KUNI</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
                </property>
               </widget>
              </item>
@@ -276,6 +300,12 @@
                  <horstretch>0</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>0</width>
+                 <height>0</height>
+                </size>
                </property>
                <property name="styleSheet">
                 <string notr="true">color: #353739; font-size: 14px;</string>
@@ -337,11 +367,20 @@
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>16</height>
+           </size>
+          </property>
           <property name="styleSheet">
            <string notr="true">color: #75787B; font-size: 11px;</string>
           </property>
           <property name="text">
            <string>STAATUS</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
           </property>
          </widget>
         </item>
@@ -352,6 +391,12 @@
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>28</height>
+           </size>
           </property>
           <property name="styleSheet">
            <string notr="true">color: #353739; font-size: 14px;</string>
@@ -398,11 +443,20 @@
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>16</height>
+           </size>
+          </property>
           <property name="styleSheet">
            <string notr="true">color: #75787B; font-size: 11px;</string>
           </property>
           <property name="text">
            <string>SERTIFIKAADID</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
           </property>
          </widget>
         </item>
@@ -413,6 +467,12 @@
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
           </property>
           <property name="styleSheet">
            <string notr="true">color: #353739; font-size: 14px;</string>
@@ -485,8 +545,8 @@
      </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>0</width>
-       <height>0</height>
+       <width>20</width>
+       <height>1</height>
       </size>
      </property>
     </spacer>

--- a/client/widgets/OtherId.ui
+++ b/client/widgets/OtherId.ui
@@ -1,0 +1,498 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>OtherId</class>
+ <widget class="QWidget" name="OtherId">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>305</width>
+    <height>220</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>305</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string/>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0">
+   <property name="spacing">
+    <number>2</number>
+   </property>
+   <property name="leftMargin">
+    <number>10</number>
+   </property>
+   <property name="topMargin">
+    <number>2</number>
+   </property>
+   <property name="rightMargin">
+    <number>10</number>
+   </property>
+   <property name="bottomMargin">
+    <number>2</number>
+   </property>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Expanding</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>1</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QWidget" name="widget" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>100</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">border: none;</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_6">
+      <item>
+       <widget class="QLabel" name="lblIdName">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>21</height>
+         </size>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">border: none; color: #041E42; font-size: 18px; 	font-weight: 500;</string>
+        </property>
+        <property name="text">
+         <string>Other ID</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="verticalSpacer_6">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>10</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <item>
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Fixed</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QWidget" name="widgetLeft" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>27</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <layout class="QHBoxLayout" name="horizontalLayout_2">
+           <property name="spacing">
+            <number>0</number>
+           </property>
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <layout class="QVBoxLayout" name="verticalLayout_4">
+             <property name="spacing">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QLabel" name="lblLeftHdr">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="styleSheet">
+                <string notr="true">color: #75787B; font-size: 11px;</string>
+               </property>
+               <property name="text">
+                <string>DOKUMENT</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="lblLeftText">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="styleSheet">
+                <string notr="true">color: #353739; font-size: 14px;</string>
+               </property>
+               <property name="text">
+                <string>PA789456123</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QWidget" name="widgetRight" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>27</height>
+           </size>
+          </property>
+          <layout class="QHBoxLayout" name="horizontalLayout_3">
+           <property name="spacing">
+            <number>0</number>
+           </property>
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <layout class="QVBoxLayout" name="verticalLayout_5">
+             <property name="spacing">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QLabel" name="lblRightHdr">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="styleSheet">
+                <string notr="true">color: #75787B; font-size: 11px;</string>
+               </property>
+               <property name="text">
+                <string>DOKUMENT KEHTIB KUNI</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="lblRightText">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="styleSheet">
+                <string notr="true">color: #353739; font-size: 14px;</string>
+               </property>
+               <property name="text">
+                <string>01.01.2022</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Fixed</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <spacer name="verticalSpacer_3">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>7</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="lblStatusHdr">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">color: #75787B; font-size: 11px;</string>
+          </property>
+          <property name="text">
+           <string>STAATUS</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="lblStatusText">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">color: #353739; font-size: 14px;</string>
+          </property>
+          <property name="text">
+           <string>Sertifikaadid on aktiivsed ja Mobiil-ID kasutamine on võimalik</string>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <spacer name="verticalSpacer_4">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>5</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <layout class="QVBoxLayout" name="verticalLayout_3">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <property name="sizeConstraint">
+         <enum>QLayout::SetDefaultConstraint</enum>
+        </property>
+        <item>
+         <widget class="QLabel" name="lblCertHdr">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">color: #75787B; font-size: 11px;</string>
+          </property>
+          <property name="text">
+           <string>SERTIFIKAADID</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="lblCertText">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">color: #353739; font-size: 14px;</string>
+          </property>
+          <property name="text">
+           <string>Kehtivad kuni 07.08.2022, 20:59:59</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <spacer name="verticalSpacer_5">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>10</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QLabel" name="lblDigiIdInfo">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">color: #75787B; font-size: 11px;</string>
+        </property>
+        <property name="text">
+         <string>Dokumendi haldamiseks sisesta kaart lugejasse</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="verticalSpacer_7">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>1</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Expanding</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
   1. Shows Mobile ID. Note, it was removed from 'eID Utility' in IB-4888 !
   2. Does not show a real Digi-ID data. New service is needed.
   3. Warning message is cleared on any mouse click.
   4. Loading progress bar is replaced with popup window (not aligned to
   center in Unix, Win - ok, OSX - ?).

Signed-off-by: Oleg Prokofjev <oleg@aktors.ee>