### PR TITLE
'My eID' -> PIN/PUK  fixes

### DIFF
--- a/client/MainWindow_MyEID.cpp
+++ b/client/MainWindow_MyEID.cpp
@@ -25,6 +25,7 @@
 
 #include "effects/FadeInNotification.h"
 #include <common/SslCertificate.h>
+#include "dialogs/CertificateDetails.h"
 
 #include <QtNetwork/QSslConfiguration>
 
@@ -94,7 +95,8 @@ void MainWindow::pinPukChange( QSmartCardData::PinType type )
 
 void MainWindow::certDetailsClicked( const QString &link )
 {
-	QMessageBox::warning( this, windowTitle(), "... Certificate details" );
+	CertificateDetails dlg( (link == "PIN1") ? smartcard->data().authCert() : smartcard->data().signCert(), this );
+	dlg.exec();
 }
 
 void MainWindow::getEmailStatus ()

--- a/client/QSmartCard.cpp
+++ b/client/QSmartCard.cpp
@@ -387,7 +387,7 @@ QSmartCard::ErrorType QSmartCard::pinChange(QSmartCardData::PinType type)
 
 	if (!d->t.isPinpad())
 	{
-		p.reset(new PinUnblock(PinUnblock::PinChange, qApp->activeWindow(), type));
+		p.reset(new PinUnblock(PinUnblock::PinChange, qApp->activeWindow(), type, d->t.retryCount(type)));
 		if (!p->exec())
 			return CancelError;
 		oldPin = p->firstCodeText().toUtf8();
@@ -407,7 +407,7 @@ QSmartCard::ErrorType QSmartCard::pinUnblock(QSmartCardData::PinType type, bool 
 
 	if (!d->t.isPinpad())
 	{
-		p.reset(new PinUnblock((isForgotPin) ? PinUnblock::ChangePinWithPuk : PinUnblock::UnBlockPinWithPuk, qApp->activeWindow(), type));
+		p.reset(new PinUnblock((isForgotPin) ? PinUnblock::ChangePinWithPuk : PinUnblock::UnBlockPinWithPuk, qApp->activeWindow(), type, d->t.retryCount(QSmartCardData::PukType)));
 		if (!p->exec())
 			return CancelError;
 		puk = p->firstCodeText().toUtf8();

--- a/client/dialogs/PinPopup.cpp
+++ b/client/dialogs/PinPopup.cpp
@@ -51,7 +51,7 @@ PinPopup::PinPopup( PinDialog::PinFlags flags, const QString &title, TokenData::
 : QDialog(parent)
 , ui(new Ui::PinPopup)
 {
-    init( flags, title, token );
+	init(flags, title, token, bodyText);
 }
 
 PinPopup::~PinPopup()

--- a/client/dialogs/PinUnblock.h
+++ b/client/dialogs/PinUnblock.h
@@ -39,7 +39,7 @@ public:
 		PinChange = 4,
 		PukChange = 8
 	};
-    PinUnblock( WorkMode mode, QWidget *parent, QSmartCardData::PinType type );
+    PinUnblock( WorkMode mode, QWidget *parent, QSmartCardData::PinType type, short leftAttempts );
     ~PinUnblock();
 
     int exec() override;
@@ -47,7 +47,7 @@ public:
 	QString newCodeText() const;
 
 private:
-    void init(  WorkMode mode, QSmartCardData::PinType type );
+    void init(  WorkMode mode, QSmartCardData::PinType type, short leftAttempts );
     void setUnblockEnabled();
 
     Ui::PinUnblock *ui;

--- a/client/dialogs/PinUnblock.ui
+++ b/client/dialogs/PinUnblock.ui
@@ -111,7 +111,7 @@ QPushButton:disabled {
    <property name="geometry">
     <rect>
      <x>108</x>
-     <y>20</y>
+     <y>10</y>
      <width>245</width>
      <height>24</height>
     </rect>
@@ -446,6 +446,30 @@ line-height: 14px;</string>
    </property>
    <property name="echoMode">
     <enum>QLineEdit::Password</enum>
+   </property>
+  </widget>
+  <widget class="QLabel" name="labelAttemptsLeft">
+   <property name="geometry">
+    <rect>
+     <x>40</x>
+     <y>40</y>
+     <width>381</width>
+     <height>20</height>
+    </rect>
+   </property>
+   <property name="styleSheet">
+    <string notr="true">border: none;
+height: 14px;
+font-size: 13px;
+color: #c53e3e;
+font-weight: 400;
+text-align: cente</string>
+   </property>
+   <property name="text">
+    <string>Katseid jäänud:</string>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignCenter</set>
    </property>
   </widget>
  </widget>


### PR DESCRIPTION
   1. Text, shown to user on change PIN/PUK with pinpad, is fixed.
   2. 'Certificate details' link is working now.
   3. On PIN/PUK change/unblock the number of left attempts is shown.
   4. UI texts are fixed.
   5. If PUK is blocked then predefined text is shown.
   6. If PUK is blocked then 'Unblock PIN1/PIN2' ('Forgot PIN code')
   buttons are hidden.

Signed-off-by: Oleg Prokofjev <oleg@aktors.ee>