### PR TITLE
File item underlined on hover + ui improvements

### DIFF
--- a/client/MainWindow.cpp
+++ b/client/MainWindow.cpp
@@ -46,6 +46,9 @@
 
 #include <QDebug>
 #include <QFileDialog>
+#include <QMessageBox>
+#include <QMimeData>
+#include <QSvgWidget>
 
 using namespace ria::qdigidoc4;
 using namespace ria::qdigidoc4::colors;
@@ -64,7 +67,7 @@ MainWindow::MainWindow( QWidget *parent ) :
 	ui->version->setFont( Styles::font( Styles::Regular, 12 ) );
 	ui->version->setText( "Ver. " + qApp->applicationVersion() );
 
-	coatOfArms = new QSvgWidget(ui->logo);
+	QSvgWidget* coatOfArms = new QSvgWidget(ui->logo);
 	coatOfArms->load( QString( ":/images/Logo_small.svg" ) );
 	coatOfArms->resize( 80, 32 );
 	coatOfArms->move( 15, 17 );
@@ -297,10 +300,6 @@ void MainWindow::hideWarningArea()
 {
 	ui->topBarShadow->setStyleSheet("background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #c8c8c8, stop: 1 #F4F5F6); \nborder: none;");
 	ui->warning->hide();
-	ui->warning->setMaximumHeight( 26 );
-	ui->warningText->setMaximumHeight( 16 );
-	ui->warningText->setWordWrap( false );
-	ui->infoStack->setMinimumSize( 186, 186 );
 }
 
 // Any mouse click inside application will hide it.
@@ -795,17 +794,6 @@ void MainWindow::savePhoto( const QPixmap *photo )
 
 void MainWindow::showWarning( const QString &msg, const QString &details, bool extLink )
 {
-	if( details.length() > 40 )
-	{
-		ui->warning->setMaximumHeight( 42 );
-		ui->warningText->setMaximumHeight( 30 );
-		ui->warningText->setWordWrap( true );
-		ui->infoStack->setMinimumSize( 178, 178 );
-	}
-	else
-	{
-        hideWarningArea();  // To restore the original warning area size
-	}
 	ui->topBarShadow->setStyleSheet("background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #b5aa92, stop: 1 #F8DDA7); \nborder: none;");	
 	ui->warning->show();
 	ui->warningText->setText( msg );

--- a/client/MainWindow.h
+++ b/client/MainWindow.h
@@ -30,9 +30,6 @@
 
 #include <QButtonGroup>
 #include <QImage>
-#include <QMessageBox>
-#include <QMimeData>
-#include <QSvgWidget>
 #include <QWidget>
 
 class DigiDoc;
@@ -152,7 +149,6 @@ bool sign();
 
 	Ui::MainWindow *ui;
 
-	QSvgWidget *coatOfArms = nullptr;
 	std::unique_ptr<CardPopup> cardPopup;
 	std::unique_ptr<Overlay> overlay;
 	DropdownButton *selector = nullptr;

--- a/client/MainWindow.ui
+++ b/client/MainWindow.ui
@@ -641,7 +641,7 @@ border: none;</string>
         <item>
          <widget class="QWidget" name="warning" native="true">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
@@ -655,7 +655,7 @@ border: none;</string>
           <property name="maximumSize">
            <size>
             <width>16777215</width>
-            <height>26</height>
+            <height>42</height>
            </size>
           </property>
           <property name="styleSheet">
@@ -681,7 +681,7 @@ color: #353739;</string>
            <item>
             <widget class="QLabel" name="warningText">
              <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
@@ -694,8 +694,8 @@ color: #353739;</string>
              </property>
              <property name="maximumSize">
               <size>
-               <width>510</width>
-               <height>16</height>
+               <width>16777215</width>
+               <height>30</height>
               </size>
              </property>
              <property name="font">
@@ -712,82 +712,71 @@ color: #353739;</string>
              <property name="text">
               <string>Üks allkiri on kehtetu!</string>
              </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
             </widget>
            </item>
            <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_3">
-             <property name="topMargin">
-              <number>0</number>
+            <widget class="QLabel" name="warningAction">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
              </property>
-             <item>
-              <spacer name="horizontalSpacer">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item>
-              <widget class="QLabel" name="warningAction">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>360</width>
-                 <height>20</height>
-                </size>
-               </property>
-               <property name="font">
-                <font>
-                 <family>Roboto</family>
-                 <pointsize>14</pointsize>
-                 <weight>75</weight>
-                 <bold>true</bold>
-                 <underline>false</underline>
-                 <strikeout>false</strikeout>
-                </font>
-               </property>
-               <property name="styleSheet">
-                <string notr="true">color: #353739;
+             <property name="minimumSize">
+              <size>
+               <width>100</width>
+               <height>20</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="font">
+              <font>
+               <family>Roboto</family>
+               <pointsize>14</pointsize>
+               <weight>75</weight>
+               <bold>true</bold>
+               <underline>false</underline>
+               <strikeout>false</strikeout>
+              </font>
+             </property>
+             <property name="styleSheet">
+              <string notr="true">color: #353739;
 font-weight: bold;
 text-decoration: none solid rgb(53, 55, 57);
 border: none;
 </string>
-               </property>
-               <property name="text">
-                <string>&lt;a href=&quot;#resolve-problem&quot; style=&quot;color: rgb(53, 55, 57)&quot;&gt;Vajuta probleemi lahendamiseks&lt;/a&gt;</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="horizontalSpacer_11">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeType">
-                <enum>QSizePolicy::Fixed</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>10</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-            </layout>
+             </property>
+             <property name="text">
+              <string>&lt;a href=&quot;#resolve-problem&quot; style=&quot;color: rgb(53, 55, 57)&quot;&gt;Vajuta probleemi lahendamiseks&lt;/a&gt;</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_11">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Fixed</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>10</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
            </item>
           </layout>
          </widget>

--- a/client/MainWindow_MyEID.cpp
+++ b/client/MainWindow_MyEID.cpp
@@ -35,6 +35,7 @@
 #include <common/Settings.h>
 
 #include <QtCore/QJsonObject>
+#include <QMessageBox>
 #include <QtNetwork/QSslConfiguration>
 #include <QtNetwork/QSslKey>
 
@@ -322,9 +323,9 @@ void MainWindow::isUpdateCertificateNeeded()
 {
 	QSmartCardData t = smartcard->data();
 
-    ui->warning->setProperty("updateCertificateEnabled",
+	ui->warning->setProperty("updateCertificateEnabled",
 		Settings(qApp->applicationName()).value("updateButton", false).toBool() ||
-        true ||                                                         // for testing. Remove it later !!!!!!
+		Settings().value("testUpdater", false).toBool() ||							// TODO for testing. Remove it later !!!!!!
 		(
 			t.version() >= QSmartCardData::VER_3_5 &&
 			t.retryCount( QSmartCardData::Pin1Type ) > 0 &&

--- a/client/dialogs/Updater.ui
+++ b/client/dialogs/Updater.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>415</width>
-    <height>300</height>
+    <width>435</width>
+    <height>318</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -18,6 +18,10 @@
   </property>
   <property name="windowTitle">
    <string>Certificate update</string>
+  </property>
+  <property name="styleSheet">
+   <string notr="true">border-radius: 2px;
+background-color: #FFFFFF;</string>
   </property>
   <layout class="QVBoxLayout" name="UpdaterLayout">
    <item>
@@ -304,6 +308,24 @@ color: #000000;
          </item>
          <item>
           <widget class="QLineEdit" name="pinInput">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>34</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>34</height>
+            </size>
+           </property>
+           <property name="styleSheet">
+            <string notr="true">padding: 0px 10px;
+border: 1px solid #DEE4E9;
+border-radius: 2px;
+</string>
+           </property>
            <property name="maxLength">
             <number>12</number>
            </property>
@@ -378,13 +400,13 @@ color: #000000;
      <property name="minimumSize">
       <size>
        <width>0</width>
-       <height>30</height>
+       <height>45</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
        <width>16777215</width>
-       <height>40</height>
+       <height>45</height>
       </size>
      </property>
      <property name="font">

--- a/client/widgets/ContainerPage.cpp
+++ b/client/widgets/ContainerPage.cpp
@@ -70,7 +70,10 @@ void ContainerPage::cardSigning(bool enable)
 	if(cardInReader != enable)
 	{
 		cardInReader = enable;
-		showSigningButton();
+		if(mainAction)
+		{
+			showSigningButton();
+		}
 	}
 }
 

--- a/client/widgets/FileItem.cpp
+++ b/client/widgets/FileItem.cpp
@@ -46,6 +46,7 @@ FileItem::FileItem( const QString& file, ContainerState state, QWidget *parent )
 : FileItem( state, parent )
 {
 	const QFileInfo f( file );
+	setMouseTracking(true);
 	ui->fileName->setText( f.fileName() );
 }
 
@@ -54,15 +55,28 @@ FileItem::~FileItem()
 	delete ui;
 }
 
+void FileItem::enterEvent(QEvent *event)
+{
+	Q_UNUSED (event);
+	ui->fileName->setStyleSheet("color: #363739; border: none; text-decoration: underline;");
+}
+
 QString FileItem::getFile()
 {
 	return ui->fileName->text();
 }
 
-void FileItem::mouseDoubleClickEvent(QMouseEvent *event)
+void FileItem::leaveEvent(QEvent *event)
+{
+	Q_UNUSED (event);
+	ui->fileName->setStyleSheet("color: #363739; border: none;");
+}
+
+void FileItem::mouseReleaseEvent(QMouseEvent *event)
 {
 	emit open(this);
 }
+
 
 void FileItem::stateChange(ContainerState state)
 {

--- a/client/widgets/FileItem.h
+++ b/client/widgets/FileItem.h
@@ -43,7 +43,9 @@ signals:
 	void download(FileItem* item);
 	
 protected:
-	void mouseDoubleClickEvent(QMouseEvent *event) override;
+	void enterEvent(QEvent *event) override;
+	void leaveEvent (QEvent *event) override;
+	void mouseReleaseEvent(QMouseEvent *event) override;
 
 private:
 	Ui::FileItem *ui;

--- a/client/widgets/VerifyCert.ui
+++ b/client/widgets/VerifyCert.ui
@@ -120,7 +120,7 @@
         <property name="minimumSize">
          <size>
           <width>0</width>
-          <height>25</height>
+          <height>33</height>
          </size>
         </property>
         <property name="font">
@@ -142,22 +142,6 @@
          <bool>true</bool>
         </property>
        </widget>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::Fixed</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>8</height>
-         </size>
-        </property>
-       </spacer>
       </item>
       <item>
        <widget class="QLabel" name="error">


### PR DESCRIPTION
- Change file item font to underlined when hovering over it
- Open file on single click instead of doubleclick
- Adjust PIN1 / PIN2 info sizes when showing warnings
- Dynamically adjust warning bar (height and width of labels)

Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>