### PR TITLE
Browse, email container functionality

### DIFF
--- a/client/DigiDoc.cpp
+++ b/client/DigiDoc.cpp
@@ -492,11 +492,9 @@ bool DigiDoc::open( const QString &file )
 		QWidget *w = qobject_cast<QWidget*>(parent());
 		if(isService())
 		{
-			QMessageBox::warning(w, w ? w->windowTitle() : 0,
-				QCoreApplication::translate("SignatureDialog",
-					"The verification of digital signatures in PDF format is performed through an external service. "
+            qApp->showWarning( tr("The verification of digital signatures in PDF format is performed through an external service. "
 					"The file requiring verification will be forwarded to the service.\n"
-					"The Information System Authority does not retain information regarding the files and users of the service."), QMessageBox::Ok);
+					"The Information System Authority does not retain information regarding the files and users of the service.") );
 		}
 		else if(isReadOnlyTS())
 		{

--- a/client/MainWindow.cpp
+++ b/client/MainWindow.cpp
@@ -49,6 +49,8 @@
 #include <QMessageBox>
 #include <QMimeData>
 #include <QSvgWidget>
+#include <QtCore/QUrlQuery>
+#include <QtGui/QDesktopServices>
 
 using namespace ria::qdigidoc4;
 using namespace ria::qdigidoc4::colors;
@@ -416,6 +418,18 @@ void MainWindow::onSignAction(int action, const QString &idCode, const QString &
 			ui->signContainerPage->transition(digiDoc);
 		}
 	}
+	else if( action == ContainerEmail && digiDoc )
+	{
+		containerToEmail( digiDoc->fileName() );
+	}
+	else if( action == ContainerNavigate && digiDoc )
+	{
+		browseOnDisk( digiDoc->fileName() );
+	}
+	else if(action == ContainerEncrypt && digiDoc)
+	{
+		navigateToPage( Pages::CryptoDetails, QStringList() << digiDoc->fileName(), true );
+	}
 }
 
 void MainWindow::onCryptoAction(int action, const QString &id, const QString &phone)
@@ -442,6 +456,14 @@ void MainWindow::onCryptoAction(int action, const QString &id, const QString &ph
 			FadeInNotification* notification = new FadeInNotification( this, WHITE, CORNFLOWER_BLUE, 110 );
 			notification->start( "Krüpteerimine õnnestus!", 750, 1500, 600 );
 		}
+		break;
+	case ContainerEmail:
+		if( cryptoDoc )
+			containerToEmail( cryptoDoc->fileName() );
+		break;
+	case ContainerNavigate:
+		if( cryptoDoc )
+			browseOnDisk( cryptoDoc->fileName() );
 		break;
 	}
 }
@@ -801,4 +823,27 @@ void MainWindow::showWarning( const QString &msg, const QString &details, bool e
 	ui->warningAction->setTextFormat( Qt::RichText );
 	ui->warningAction->setTextInteractionFlags( Qt::TextBrowserInteraction );
 	ui->warningAction->setOpenExternalLinks( extLink );
+}
+
+void MainWindow::containerToEmail( const QString &fileName )
+{
+	QUrlQuery q;
+	QUrl url;
+
+	if ( !QFileInfo( fileName ).exists() )
+		return;
+	q.addQueryItem( "subject", QFileInfo( fileName ).fileName() );
+	q.addQueryItem( "attachment", QFileInfo( fileName ).absoluteFilePath() );
+	url.setScheme( "mailto" );
+	url.setQuery(q);
+	QDesktopServices::openUrl( url );
+}
+
+void MainWindow::browseOnDisk( const QString &fileName )
+{
+	if ( !QFileInfo( fileName ).exists() )
+		return;
+	QUrl url = QUrl::fromLocalFile( fileName );
+	url.setScheme( "browse" );
+	QDesktopServices::openUrl( url );
 }

--- a/client/MainWindow.h
+++ b/client/MainWindow.h
@@ -139,10 +139,12 @@ private:
 	void showOverlay( QWidget *parent );
 	void showNotification( const QString &msg, bool isSuccess = false );
 	void showWarning( const QString &msg, const QString &details, bool extLink = false );
-bool sign();
+	bool sign();
 	bool signMobile(const QString &idCode, const QString &phoneNumber);
 	void updateCardData();
 	bool validateCardError( QSmartCardData::PinType type, int flags, QSmartCard::ErrorType err );
+	void containerToEmail( const QString &fileName );
+	void browseOnDisk( const QString &fileName );
 	
 	CryptoDoc* cryptoDoc = nullptr;
 	DigiDoc* digiDoc = nullptr;

--- a/client/MainWindow_MyEID.cpp
+++ b/client/MainWindow_MyEID.cpp
@@ -67,10 +67,7 @@ void MainWindow::changePin2Clicked( bool isForgotPin, bool isBlockedPin )
 
 void MainWindow::changePukClicked( bool isForgotPuk )
 {
-	if( isForgotPuk )
-		QMessageBox::warning( this, windowTitle(), "... PUK forgotten" );
-	else
-		pinPukChange( QSmartCardData::PukType );
+	pinPukChange( QSmartCardData::PukType );
 }
 
 void MainWindow::pinUnblock( QSmartCardData::PinType type, bool isForgotPin )

--- a/client/dialogs/WarningDialog.ui
+++ b/client/dialogs/WarningDialog.ui
@@ -3,14 +3,14 @@
  <class>WarningDialog</class>
  <widget class="QDialog" name="WarningDialog">
   <property name="windowModality">
-   <enum>Qt::WindowModal</enum>
+   <enum>Qt::ApplicationModal</enum>
   </property>
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
     <width>420</width>
-    <height>145</height>
+    <height>206</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -59,6 +59,9 @@ background-color: #FFFFFF;</string>
        <pointsize>14</pointsize>
       </font>
      </property>
+     <property name="cursor">
+      <cursorShape>IBeamCursor</cursorShape>
+     </property>
      <property name="styleSheet">
       <string notr="true">margin: 10px 15px 0px 15px;</string>
      </property>
@@ -67,9 +70,6 @@ background-color: #FFFFFF;</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-     <property name="cursor">
-       <cursorShape>IBeamCursor</cursorShape>
      </property>
     </widget>
    </item>
@@ -106,14 +106,14 @@ background-color: #FFFFFF;</string>
        <height>30</height>
       </size>
      </property>
+     <property name="cursor">
+      <cursorShape>IBeamCursor</cursorShape>
+     </property>
      <property name="styleSheet">
       <string notr="true">margin: 0px 15px 0px 15px;</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-     <property name="cursor">
-      <cursorShape>IBeamCursor</cursorShape>
      </property>
     </widget>
    </item>

--- a/client/widgets/ContainerPage.cpp
+++ b/client/widgets/ContainerPage.cpp
@@ -82,12 +82,13 @@ void ContainerPage::elideFileName(bool force)
 	if(ui->containerFile->width() < containerFileWidth)
 	{
 		elided = true;
-		ui->containerFile->setText(fm.elidedText(fileName, Qt::ElideMiddle, ui->containerFile->width()));
+		ui->containerFile->setText("<a href='#browse-Container'><span style='color:rgb(53, 55, 57)'>" +
+			fm.elidedText(fileName, Qt::ElideMiddle, ui->containerFile->width()) + "</span></a>");
 	}
 	else if(elided || force)
 	{
 		elided = false;
-		ui->containerFile->setText(fileName);
+		ui->containerFile->setText("<a href='#browse-Container'><span style='color:rgb(53, 55, 57)'>" + fileName + "</span></a>");
 	}
 }
 
@@ -110,11 +111,20 @@ void ContainerPage::init()
 	connect(ui->save, &LabelButton::clicked, this, &ContainerPage::forward);
 	connect(ui->leftPane, &ItemList::addItem, this, &ContainerPage::forward);
 	connect(ui->rightPane, &ItemList::addItem, this, &ContainerPage::forward);
+	connect(ui->email, &LabelButton::clicked, this, &ContainerPage::forward);
+	connect(ui->navigateToContainer, &LabelButton::clicked, this, &ContainerPage::forward);
+	connect(ui->encrypt, &LabelButton::clicked, this, &ContainerPage::forward);
+	connect(ui->containerFile, &QLabel::linkActivated, this, &ContainerPage::browseContainer );
 }
 
 void ContainerPage::forward(int code)
 {
 	emit action(code);
+}
+
+void ContainerPage::browseContainer(QString link)
+{
+	emit action(Actions::ContainerNavigate, link);
 }
 
 void ContainerPage::initContainer( const QString &file, const QString &suffix )

--- a/client/widgets/ContainerPage.h
+++ b/client/widgets/ContainerPage.h
@@ -62,6 +62,7 @@ private:
 	void clear();
 	void elideFileName(bool force = false);
 	void forward(int code);
+	void browseContainer(QString link);
 	void hideButtons( std::vector<QWidget*> buttons );
 	void hideMainAction();
 	void hideOtherAction();

--- a/client/widgets/VerifyCert.cpp
+++ b/client/widgets/VerifyCert.cpp
@@ -97,8 +97,8 @@ void VerifyCert::update( QSmartCardData::PinType type, const QSmartCard *pSmartC
 		case QSmartCardData::Pin1Type:
 			name = "Isikutuvastamise sertifikaat";
 			changeBtn = ( !isValidCert ) ? "UUENDA SERTIFIKAAT" : ( isBlockedPin ) ? "TÜHISTA BLOKEERING" : "MUUDA PIN1";
-			forgotPinText = "<a href='#pin1-forgotten'><span style='color:black;'>Unustasid PIN1 koodi?</span></a>";
-			detailsText = ( isValidCert ) ? "<a href='#pin1-cert'><span style='color:black;'>Vaata sertifikaadi detaile</span></a>" : "";
+			forgotPinText = "<a href='#pin1-forgotten'><span style='color:#75787B;'>Unustasid PIN1 koodi?</span></a>";
+			detailsText = ( isValidCert ) ? "<a href='#pin1-cert'><span style='color:#75787B;'>Vaata sertifikaadi detaile</span></a>" : "";
 			error = ( !isValidCert ) ? "PIN1 ei saa kasutada, kuna sertifikaat on aegunud. Uuenda sertifikaat, et PIN1 taas kasutada." :
 					( isBlockedPin ) ? "PIN1 on blokeeritud, kuna PIN1 koodi on sisestatud 3 korda valesti. Tühista blokeering, et PIN1 taas kasutada." :
 					"";
@@ -106,8 +106,8 @@ void VerifyCert::update( QSmartCardData::PinType type, const QSmartCard *pSmartC
 		case QSmartCardData::Pin2Type:
 			name = "Allkirjastamise sertifikaat";
 			changeBtn = ( !isValidCert ) ? "UUENDA SERTIFIKAAT" : ( isBlockedPin ) ? "TÜHISTA BLOKEERING" : "MUUDA PIN2";
-			forgotPinText = "<a href='#pin2-forgotten'><span style='color:black;'>Unustasid PIN2 koodi?</span></a>";
-			detailsText = ( isValidCert ) ? "<a href='#pin2-cert'><span style='color:black;'>Vaata sertifikaadi detaile</span></a>" : "";
+			forgotPinText = "<a href='#pin2-forgotten'><span style='color:#75787B;'>Unustasid PIN2 koodi?</span></a>";
+			detailsText = ( isValidCert ) ? "<a href='#pin2-cert'><span style='color:#75787B;'>Vaata sertifikaadi detaile</span></a>" : "";
 			error = ( !isValidCert ) ? "PIN2 ei saa kasutada, kuna sertifikaat on aegunud. Uuenda sertifikaat, et PIN2 taas kasutada." :
 					( isBlockedPin ) ? "PIN2 on blokeeritud, kuna PIN2 koodi on sisestatud 3 korda valesti. Tühista blokeering, et PIN2 taas kasutada." : 
 					"";


### PR DESCRIPTION
   1. Browse on disk (or email) container on Sign/Crypto pages (click on
   existing container link will open browse window).
   2. Encrypt document from Sign page.
   3. Warning dialog to be modal.
   4. MyeID->'Forgot PIN code?' in grey color.

Signed-off-by: Oleg Prokofjev <oleg@aktors.ee>