### PR TITLE
Layout fixes. My eID fixes.

### DIFF
--- a/client/MainWindow.cpp
+++ b/client/MainWindow.cpp
@@ -306,12 +306,15 @@ void MainWindow::hideWarningArea()
 	ui->warning->hide();
 }
 
-// Any mouse click inside application will hide it.
 void MainWindow::mousePressEvent(QMouseEvent *event)
 {
-	if( !ui->warning->property("updateCertificateEnabled").toBool() &&
-		ui->warning->underMouse() )
-		hideWarningArea();
+	if( ui->warning->underMouse() )
+	{
+		if( ui->warning->property("updateCertificateEnabled").toBool() )
+			showUpdateCertWarning();
+		else
+			hideWarningArea();
+	}
 }
 
 void MainWindow::navigateToPage( Pages page, const QStringList &files, bool create )
@@ -721,8 +724,7 @@ void MainWindow::showCardStatus()
 		isUpdateCertificateNeeded();
 		ui->myEid->updateCertNeededIcon( ui->warning->property("updateCertificateEnabled").toBool() );
 		if( ui->warning->property("updateCertificateEnabled").toBool() )
-			showWarning("Kaardi sertifikaadid vajavad uuendamist. Uuendamine võtab aega 2-10 minutit ning eeldab toimivat internetiühendust. Kaarti ei tohi lugejast enne uuenduse lõppu välja võtta.",
-				"<a href='#update-Certificate'><span style='color:rgb(53, 55, 57)'>Uuenda</span></a>");
+			showUpdateCertWarning();
 	}
 	else
 	{
@@ -834,6 +836,7 @@ void MainWindow::noReader_NoCard_Loading_Event( const QString &text, bool isLoad
 	ui->myEid->invalidCertIcon( false );
 	ui->myEid->pinIsBlockedIcon( false );
 	ui->myEid->updateCertNeededIcon( false );
+	ui->warning->setProperty( "updateCertificateEnabled", false );
 	hideWarningArea();
 }
 
@@ -925,4 +928,10 @@ void MainWindow::browseOnDisk( const QString &fileName )
 	QUrl url = QUrl::fromLocalFile( fileName );
 	url.setScheme( "browse" );
 	QDesktopServices::openUrl( url );
+}
+
+void MainWindow::showUpdateCertWarning()
+{
+	showWarning("Kaardi sertifikaadid vajavad uuendamist. Uuendamine võtab aega 2-10 minutit ning eeldab toimivat internetiühendust. Kaarti ei tohi lugejast enne uuenduse lõppu välja võtta.",
+		"<a href='#update-Certificate'><span style='color:rgb(53, 55, 57)'>Uuenda</span></a>");
 }

--- a/client/MainWindow.h
+++ b/client/MainWindow.h
@@ -149,6 +149,7 @@ private:
 	bool validateCardError( QSmartCardData::PinType type, int flags, QSmartCard::ErrorType err );
 	void containerToEmail( const QString &fileName );
 	void browseOnDisk( const QString &fileName );
+	void showUpdateCertWarning();
 	
 	CryptoDoc* cryptoDoc = nullptr;
 	DigiDoc* digiDoc = nullptr;

--- a/client/MainWindow.ui
+++ b/client/MainWindow.ui
@@ -786,7 +786,7 @@ border: none;
           <property name="minimumSize">
            <size>
             <width>914</width>
-            <height>505</height>
+            <height>491</height>
            </size>
           </property>
           <property name="maximumSize">
@@ -1173,6 +1173,12 @@ color: #041E42;</string>
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>491</height>
+            </size>
+           </property>
            <property name="styleSheet">
             <string notr="true">border: none;
 background-color: #F4F5F6;</string>
@@ -1196,7 +1202,7 @@ background-color: #F4F5F6;</string>
             <item>
              <widget class="InfoStack" name="infoStack" native="true">
               <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>
@@ -1204,6 +1210,12 @@ background-color: #F4F5F6;</string>
               <property name="minimumSize">
                <size>
                 <width>0</width>
+                <height>172</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
                 <height>186</height>
                </size>
               </property>

--- a/client/MainWindow_MyEID.cpp
+++ b/client/MainWindow_MyEID.cpp
@@ -273,6 +273,9 @@ void MainWindow::getOtherEID ()
 
 void MainWindow::getMobileIdStatus ()
 {
+	if (smartcard->data().retryCount( QSmartCardData::Pin1Type ) == 0)
+		return;
+    
 	QByteArray buffer = sendRequest( SSLConnect::MobileInfo );
 	if( buffer.isEmpty() )
 		return;

--- a/client/widgets/CardPopup.cpp
+++ b/client/widgets/CardPopup.cpp
@@ -31,7 +31,7 @@ CardPopup::CardPopup( const QSmartCard *smartCard, QWidget *parent )
 	QString selected = smartCard->data().card();
 	auto cards = smartCard->data().cards();
 
-	resize( WIDTH, (cards.size() - 1) * ROW_HEIGHT + BORDER_WIDTH );
+	resize( WIDTH, (cards.size() - 1) * ROW_HEIGHT + ( (cards.size() > 1) ? BORDER_WIDTH : 0 ) );
 	move( X_POSITION, ROW_HEIGHT );
 	setStyleSheet( "border: solid rgba(217, 217, 216, 0.45); border-width: 0px 2px 2px 1px; background-color: rgba(255, 255, 255, 0.95);" );
 

--- a/client/widgets/ContainerPage.ui
+++ b/client/widgets/ContainerPage.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>914</width>
-    <height>535</height>
+    <height>491</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -19,7 +19,7 @@
   <property name="minimumSize">
    <size>
     <width>914</width>
-    <height>505</height>
+    <height>475</height>
    </size>
   </property>
   <property name="windowTitle">

--- a/client/widgets/VerifyCert.cpp
+++ b/client/widgets/VerifyCert.cpp
@@ -76,8 +76,8 @@ void VerifyCert::update( QSmartCardData::PinType type, const QSmartCard *pSmartC
 	QSmartCardData t = pSmartCard->data();
 	
 	SslCertificate c = ( type == QSmartCardData::Pin1Type ) ? t.authCert() : t.signCert();
-	this->isValidCert = c.isValid();	// put 0 for testing Aegunud Sertifikaate.
-	this->isBlockedPin = (t.retryCount( type ) == 0) ? true : false; // put 1 for testing Tühista Blokeering.
+	this->isValidCert = c.isValid();
+	this->isBlockedPin = (t.retryCount( type ) == 0) ? true : false;
 
 	if( !isValidCert )
 	{
@@ -96,18 +96,18 @@ void VerifyCert::update( QSmartCardData::PinType type, const QSmartCard *pSmartC
 	{
 		case QSmartCardData::Pin1Type:
 			name = "Isikutuvastamise sertifikaat";
-			changeBtn = ( !isValidCert ) ? "UUENDA SERTIFIKAAT" : ( isBlockedPin ) ? "TÜHISTA BLOKEERING" : "MUUDA PIN1";
+			changeBtn = ( isBlockedPin ) ? "TÜHISTA BLOKEERING" : "MUUDA PIN1";
 			forgotPinText = "<a href='#pin1-forgotten'><span style='color:#75787B;'>Unustasid PIN1 koodi?</span></a>";
-			detailsText = ( isValidCert ) ? "<a href='#pin1-cert'><span style='color:#75787B;'>Vaata sertifikaadi detaile</span></a>" : "";
+			detailsText = "<a href='#pin1-cert'><span style='color:#75787B;'>Vaata sertifikaadi detaile</span></a>";
 			error = ( !isValidCert ) ? "PIN1 ei saa kasutada, kuna sertifikaat on aegunud. Uuenda sertifikaat, et PIN1 taas kasutada." :
 					( isBlockedPin ) ? "PIN1 on blokeeritud, kuna PIN1 koodi on sisestatud 3 korda valesti. Tühista blokeering, et PIN1 taas kasutada." :
 					"";
 			break;
 		case QSmartCardData::Pin2Type:
 			name = "Allkirjastamise sertifikaat";
-			changeBtn = ( !isValidCert ) ? "UUENDA SERTIFIKAAT" : ( isBlockedPin ) ? "TÜHISTA BLOKEERING" : "MUUDA PIN2";
+			changeBtn = ( isBlockedPin ) ? "TÜHISTA BLOKEERING" : "MUUDA PIN2";
 			forgotPinText = "<a href='#pin2-forgotten'><span style='color:#75787B;'>Unustasid PIN2 koodi?</span></a>";
-			detailsText = ( isValidCert ) ? "<a href='#pin2-cert'><span style='color:#75787B;'>Vaata sertifikaadi detaile</span></a>" : "";
+			detailsText = "<a href='#pin2-cert'><span style='color:#75787B;'>Vaata sertifikaadi detaile</span></a>";
 			error = ( !isValidCert ) ? "PIN2 ei saa kasutada, kuna sertifikaat on aegunud. Uuenda sertifikaat, et PIN2 taas kasutada." :
 					( isBlockedPin ) ? "PIN2 on blokeeritud, kuna PIN2 koodi on sisestatud 3 korda valesti. Tühista blokeering, et PIN2 taas kasutada." : 
 					"";
@@ -225,14 +225,6 @@ void VerifyCert::update(
 			ui->validUntil->setVisible( false );
 			ui->changePIN->hide();  // hide 'change PUK' button
 		}
-	}
-	if( !isValidCert )
-	{
-		// This logic to be clarified!													 TODO!!
-		if( pinType != QSmartCardData::PukType )
-			ui->changePIN->hide();  // hide 'change PIN' buttons.
-		if( pinType != QSmartCardData::PukType )
-			ui->forgotPinLink->setVisible( false ); // hide 'Forgot PIN. code?' label
 	}
 	ui->validUntil->setText( validUntil );
 	if( pinType != QSmartCardData::PukType )


### PR DESCRIPTION
     1. When 'Update Certificate' warning message is shown then
     Sign/Crypto had cutted navigation bar. My eID had issue with blocked pin
     cutted text.
     2. Pressig Id Card Info widget with one card in reader showed not
     needed border's line.
     3. 'My eID' 'expired certificates' functionality to be  like in current
     Utility.
     4. 'Update Certificate' warning to be shown back (if needed) after user clicked
     mouse on overlay warning message.
     5. My eID->Other's eIDs: do not ask PIN1 code if it is blocked.

Signed-off-by: Oleg Prokofjev <oleg@aktors.ee>