### PR TITLE
Apply the lates changes from qesteidutil

### DIFF
--- a/client/Application.cpp
+++ b/client/Application.cpp
@@ -814,12 +814,12 @@ void Application::showClient( const QStringList &params )
 
 void Application::showTSLWarning(QEventLoop *e)
 {
-	e->exit( QMessageBox::information(
-		qApp->activeWindow(), Application::tr("DigiDoc4 Client"), Application::tr(
+	showWarning( tr(
 		"The renewal of Trust Service status List, used for digital signature validation, has failed. "
 		"Please check your internet connection and make sure you have the latest ID-software version "
 		"installed. An expired Trust Service List (TSL) will be used for signature validation. "
-		"<a href=\"http://www.id.ee/?id=37012\">Additional information</a>") ) );
+		"<a href=\"http://www.id.ee/?id=37012\">Additional information</a>") );
+	e->exit();
 }
 
 void Application::showWarning( const QString &msg, const digidoc::Exception &e )

--- a/client/CertStore.cpp
+++ b/client/CertStore.cpp
@@ -1,5 +1,5 @@
 /*
- * QDigiDoc4
+ * QEstEidUtil
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -20,6 +20,9 @@
 #include "CertStore.h"
 
 #include <common/SslCertificate.h>
+
+#include <QtCore/QtEndian>
+#include <QtNetwork/QSslKey>
 
 #include <qt_windows.h>
 #include <WinCrypt.h>
@@ -60,12 +63,38 @@ bool CertStore::add( const QSslCertificate &cert, const QString &card )
 
 	SslCertificate c( cert );
 	DWORD keyCode = c.keyUsage().contains( SslCertificate::NonRepudiation ) ? AT_SIGNATURE : AT_KEYEXCHANGE;
-	QString cardStr = card + (keyCode == AT_SIGNATURE ? "_SIG" : "_AUT" );
-	cardStr = QCryptographicHash::hash( cardStr.toUtf8(), QCryptographicHash::Md5 ).toHex();
 
 	PCCERT_CONTEXT context = d->certContext( cert );
 	if(!context)
 		return false;
+
+	auto _ntohs = [](quint16 x) {
+		return QSysInfo::ByteOrder == QSysInfo::BigEndian ? x : qbswap<quint16>(x);
+	};
+	auto _ntohl = [](quint32 x) {
+		return QSysInfo::ByteOrder == QSysInfo::BigEndian ? x : qbswap<quint32>(x);
+	};
+
+	DWORD size = 20;
+	QByteArray hash(int(size), 0);
+	CertGetCertificateContextProperty(context, CERT_SHA1_HASH_PROP_ID, hash.data(), &size);
+	GUID g;
+	// convert UUID to local byte order
+	memcpy(&g, hash.data(), sizeof(g));
+	g.Data1 = _ntohl(g.Data1);
+	g.Data2 = _ntohs(g.Data2);
+	g.Data3 = _ntohs(g.Data3);
+
+	// put in the variant and version bits
+	g.Data3 &= 0xFFF;
+	g.Data3 |= (5 << 12);
+	g.Data4[0] &= 0x3F;
+	g.Data4[0] |= 0x80;
+
+	std::wstring guid(40, 0);
+	swprintf(&guid[0], sizeof(guid) / 2, L"%8.8x-%4.4x-%4.4x-%2.2x%2.2x-%2.2x%2.2x%2.2x%2.2x%2.2x%2.2x",
+		g.Data1, g.Data2, g.Data3, g.Data4[0], g.Data4[1], g.Data4[2],
+		g.Data4[3], g.Data4[4], g.Data4[5], g.Data4[6], g.Data4[7]);
 
 	QString str = QString( "%1 %2" )
 		.arg( keyCode == AT_SIGNATURE ? "Signature" : "Authentication" )
@@ -73,9 +102,11 @@ bool CertStore::add( const QSslCertificate &cert, const QString &card )
 	CRYPT_DATA_BLOB DataBlob = { (str.length() + 1) * sizeof(QChar), (BYTE*)str.utf16() };
 	CertSetCertificateContextProperty( context, CERT_FRIENDLY_NAME_PROP_ID, 0, &DataBlob );
 
-	CRYPT_KEY_PROV_INFO KeyProvInfo =
-	{ LPWSTR(cardStr.utf16()), L"Microsoft Base Smart Card Crypto Provider", PROV_RSA_FULL, 0, 0, 0, keyCode };
-	CertSetCertificateContextProperty( context, CERT_KEY_PROV_INFO_PROP_ID, 0, &KeyProvInfo );
+	CRYPT_KEY_PROV_INFO RSAKeyProvInfo  =
+	{ &guid[0], L"Microsoft Base Smart Card Crypto Provider", PROV_RSA_FULL, 0, 0, 0, keyCode };
+	CRYPT_KEY_PROV_INFO ECKeyProvInfo =  
+	{ &guid[0], L"Microsoft Smart Card Key Storage Provider", 0, 0, 0, 0, 0 }; 
+	CertSetCertificateContextProperty(context, CERT_KEY_PROV_INFO_PROP_ID, 0, cert.publicKey().algorithm() == QSsl::Rsa ? &RSAKeyProvInfo : &ECKeyProvInfo);  
 
 	bool result = CertAddCertificateContextToStore( d->s, context, CERT_STORE_ADD_REPLACE_EXISTING, 0 );
 	CertFreeCertificateContext( context );

--- a/client/MainWindow.h
+++ b/client/MainWindow.h
@@ -73,45 +73,6 @@ protected:
 	void resizeEvent( QResizeEvent *event ) override;
 
 private:
-	enum ButtonTypes
-	{
-		PageEmpty = 0x00,
-
-		PageCert = 0x01,
-		PageCertAuthView = 0x11,
-		PageCertSignView = 0x21,
-		PageCertPin1 = 0x31,
-		PageCertPin2 = 0x41,
-		PageCertUpdate = 0x51,
-
-		PageEmail = 0x02,
-		PageEmailStatus = 0x12,
-		PageEmailActivate = 0x22,
-
-		PageMobile = 0x03,
-		PageMobileStatus = 0x13,
-		PageMobileActivate = 0x23,
-
-		PagePukInfo = 0x04,
-
-		PagePin1Pin = 0x05,
-		PagePin1Puk = 0x15,
-		PagePin1Unblock = 0x25,
-		PagePin1ChangePin = 0x35,
-		PagePin1ChangePuk = 0x45,
-		PagePin1ChangeUnblock = 0x55,
-
-		PagePin2Pin = 0x06,
-		PagePin2Puk = 0x16,
-		PagePin2Unblock = 0x26,
-		PagePin2ChangePin = 0x36,
-		PagePin2ChangePuk = 0x46,
-		PagePin2ChangeUnblock = 0x56,
-
-		PagePuk = 0x07,
-		PagePukChange = 0x17
-	};
-
 	void noReader_NoCard_Loading_Event( const QString &text, bool isLoading = false );
 	void cachePicture( const QString &id, const QImage &image );
 	void clearOverlay();
@@ -152,6 +113,7 @@ private:
 	void containerToEmail( const QString &fileName );
 	void browseOnDisk( const QString &fileName );
 	void showUpdateCertWarning();
+	void showIdCardAlerts(const QSmartCardData& t);
 	
 	CryptoDoc* cryptoDoc = nullptr;
 	DigiDoc* digiDoc = nullptr;

--- a/client/MainWindow_MyEID.cpp
+++ b/client/MainWindow_MyEID.cpp
@@ -328,6 +328,7 @@ void MainWindow::isUpdateCertificateNeeded()
 		Settings().value("testUpdater", false).toBool() ||							// TODO for testing. Remove it later !!!!!!
 		(
 			t.version() >= QSmartCardData::VER_3_5 &&
+			t.appletVersion() != "3.5.8" &&
 			t.retryCount( QSmartCardData::Pin1Type ) > 0 &&
 			t.isValid() &&
 			Configuration::instance().object().contains("EIDUPDATER-URL-TOECC") && (

--- a/client/QSmartCard.h
+++ b/client/QSmartCard.h
@@ -91,6 +91,7 @@ public:
 	SslCertificate signCert() const;
 	quint8 retryCount( PinType type ) const;
 	ulong usageCount( PinType type ) const;
+	QString appletVersion() const;
 	CardVersion version() const;
 
 	static QString typeString( PinType type );

--- a/client/dialogs/Updater.cpp
+++ b/client/dialogs/Updater.cpp
@@ -40,7 +40,6 @@
 #include <QtNetwork/QSslKey>
 #include <QtGui/QPainter>
 #include <QtWidgets/QPushButton>
-#include <QPalette>
 
 #include <openssl/evp.h>
 #include <openssl/rsa.h>
@@ -288,7 +287,6 @@ Updater::Updater(const QString &reader, QWidget *parent)
 {
 	d->setupUi(this);
     setWindowFlags( Qt::Dialog | Qt::FramelessWindowHint );
-//	setWindowFlags(((windowFlags() & ~Qt::WindowContextHelpButtonHint) | Qt::CustomizeWindowHint) & ~Qt::WindowCloseButtonHint);
     setWindowModality( Qt::ApplicationModal );
 	d->statusTimer = new QTimeLine(d->pinProgress->maximum() * 1000, d->pinProgress);
 	d->statusTimer->setCurveShape(QTimeLine::LinearCurve);
@@ -579,10 +577,7 @@ int Updater::exec()
 	// Do connection
 	QNetworkAccessManager *net = new QNetworkAccessManager(this);
 	d->request = QNetworkRequest(QUrl(
-		Configuration::instance().object().value("EIDUPDATER-URL").toString()));
-// Newer version: https://github.com/open-eid/qesteidutil/commit/b94f1af56c0be70186c2f67e7334080f68047bc5
-// requires a new version of config file: C:\Users\user.name\AppData\Roaming\RIA\qesteidutil\config.json
-//		Configuration::instance().object().value("EIDUPDATER-URL-TOECC").toString()));
+		Configuration::instance().object().value("EIDUPDATER-URL-TOECC").toString()));
 	d->request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
 	d->request.setRawHeader("User-Agent", QString("%1/%2 (%3)")
 		.arg(qApp->applicationName(), qApp->applicationVersion(), Common::applicationOs()).toUtf8());

--- a/client/dialogs/WarningDialog.cpp
+++ b/client/dialogs/WarningDialog.cpp
@@ -36,7 +36,8 @@ WarningDialog::WarningDialog(const QString &text, const QString &details, QWidge
 	ui->cancel->setFont(Styles::font(Styles::Condensed, 14));
 	ui->text->setFont(regular);
 	ui->text->setText(text);
-	ui->text->setTextInteractionFlags(Qt::TextSelectableByMouse);
+	ui->text->setTextInteractionFlags(ui->text->textInteractionFlags() | Qt::TextSelectableByMouse);
+
 	if(details.isNull())
 	{
 		ui->details->hide();

--- a/client/widgets/VerifyCert.cpp
+++ b/client/widgets/VerifyCert.cpp
@@ -78,6 +78,7 @@ void VerifyCert::update( QSmartCardData::PinType type, const QSmartCard *pSmartC
 	SslCertificate c = ( type == QSmartCardData::Pin1Type ) ? t.authCert() : t.signCert();
 	this->isValidCert = c.isValid();
 	this->isBlockedPin = (t.retryCount( type ) == 0) ? true : false;
+	ui->changePIN->show();
 
 	if( !isValidCert )
 	{
@@ -97,7 +98,7 @@ void VerifyCert::update( QSmartCardData::PinType type, const QSmartCard *pSmartC
 		case QSmartCardData::Pin1Type:
 			name = "Isikutuvastamise sertifikaat";
 			changeBtn = ( isBlockedPin ) ? "TÜHISTA BLOKEERING" : "MUUDA PIN1";
-			forgotPinText = "<a href='#pin1-forgotten'><span style='color:#75787B;'>Unustasid PIN1 koodi?</span></a>";
+			forgotPinText = ( !t.isSecurePinpad() ) ? "<a href='#pin1-forgotten'><span style='color:#75787B;'>Unustasid PIN1 koodi?</span></a>" : "";
 			detailsText = "<a href='#pin1-cert'><span style='color:#75787B;'>Vaata sertifikaadi detaile</span></a>";
 			error = ( !isValidCert ) ? "PIN1 ei saa kasutada, kuna sertifikaat on aegunud. Uuenda sertifikaat, et PIN1 taas kasutada." :
 					( isBlockedPin ) ? "PIN1 on blokeeritud, kuna PIN1 koodi on sisestatud 3 korda valesti. Tühista blokeering, et PIN1 taas kasutada." :
@@ -106,7 +107,7 @@ void VerifyCert::update( QSmartCardData::PinType type, const QSmartCard *pSmartC
 		case QSmartCardData::Pin2Type:
 			name = "Allkirjastamise sertifikaat";
 			changeBtn = ( isBlockedPin ) ? "TÜHISTA BLOKEERING" : "MUUDA PIN2";
-			forgotPinText = "<a href='#pin2-forgotten'><span style='color:#75787B;'>Unustasid PIN2 koodi?</span></a>";
+			forgotPinText = ( !t.isSecurePinpad() ) ? "<a href='#pin2-forgotten'><span style='color:#75787B;'>Unustasid PIN2 koodi?</span></a>" : "";
 			detailsText = "<a href='#pin2-cert'><span style='color:#75787B;'>Vaata sertifikaadi detaile</span></a>";
 			error = ( !isValidCert ) ? "PIN2 ei saa kasutada, kuna sertifikaat on aegunud. Uuenda sertifikaat, et PIN2 taas kasutada." :
 					( isBlockedPin ) ? "PIN2 on blokeeritud, kuna PIN2 koodi on sisestatud 3 korda valesti. Tühista blokeering, et PIN2 taas kasutada." : 
@@ -121,6 +122,7 @@ void VerifyCert::update( QSmartCardData::PinType type, const QSmartCard *pSmartC
 				"<br><br>Kuigi PUK kood on blokeeritud, saab kõiki eID võimalusi kasutada, välja arvatud PUK koodi vajavaid."
 				"<br><br>Uue PUK koodi saad vaid uue koodiümbrikuga, mida <u>taotle PPA-st</u></span>."
 				: "";
+			ui->changePIN->setDisabled( t.version() == QSmartCardData::VER_USABLEUPDATER );
 			break;
 		default:
 			break;
@@ -202,7 +204,6 @@ void VerifyCert::update(
 			( ( pinType != QSmartCardData::PukType ) ? " <img src=\":/images/icon_check.svg\" height=\"12\" width=\"13\">" : "" ) );
 	}
 	ui->name->setTextFormat( Qt::RichText );
-	ui->changePIN->show();
 
 	ui->forgotPinLink->setText( forgotPinText );
 	ui->forgotPinLink->setVisible( !forgotPinText.isEmpty() );


### PR DESCRIPTION
      1. Applied ECDSA token support changes
      2. Applet version (without client changes)
      3. No 'translations' changes applied.
      4. Added 'Certificate is not registered' alert
      5. Added 'ID-card can not be renewed from 1.7.2017' alert.
      6. applied current qesteidutil logic:
         - if authentication certificate is missing then do not show it.
         - if signing certificate is missing then do not show it.
	 - if card is for eResident do not show e-mail checking tab.
	 - for certain PinPad types do not show 'Forgotten PIN' link.
	 - for some card version do not allow PUK change

Signed-off-by: Oleg Prokofjev <oleg@aktors.ee>