### PR TITLE
libdigidocpp & Xerces 3.2 dependency updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,7 @@ before_install:
     HASH=($(shasum prepare_osx_build_environment.sh | cut -d ' ' -f 1));
     pip install --user awscli > /dev/null;
     export PATH=$PATH:`echo ~/Library/Python/*/bin` ;
-    aws s3 cp s3://open-eid-digidoc4/cache/${TARGET}/opensc.pkg.zip opensc.pkg.zip --no-sign-request;
-    unzip opensc.pkg.zip;
+    aws s3 cp s3://open-eid-digidoc4/cache/${TARGET}/opensc.pkg opensc.pkg --no-sign-request;
     sudo installer -verboseR -pkg opensc.pkg -target /;
     aws s3 cp s3://open-eid-digidoc4/cache/${TARGET}/${HASH}.zip ${HASH}.zip --no-sign-request;
     if [ $? -eq 0 ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,14 @@ before_install:
     brew install --force openssl;
     curl -s --location "https://github.com/open-eid/libdigidoc/releases/download/v3.10.3/libdigidoc_3.10.3.1214.pkg" -o libdigidoc.pkg;
     curl -s --location "https://github.com/open-eid/libdigidocpp/releases/download/v3.13.2/libdigidocpp_3.13.2.1360.pkg" -o libdigidocpp.pkg;
-    curl -s --location "https://github.com/open-eid/esteid-pkcs11/releases/download/v3.10.1/esteid-pkcs11_3.10.1.64.pkg" -o esteid-pkcs11.pkg;
     sudo installer -verboseR -pkg libdigidoc.pkg -target /;
     sudo installer -verboseR -pkg libdigidocpp.pkg -target /;
-    sudo installer -verboseR -pkg esteid-pkcs11.pkg -target /;
     HASH=($(shasum prepare_osx_build_environment.sh | cut -d ' ' -f 1));
     pip install --user awscli > /dev/null;
     export PATH=$PATH:`echo ~/Library/Python/*/bin` ;
+    aws s3 cp s3://open-eid-digidoc4/cache/${TARGET}/opensc.pkg.zip opensc.pkg.zip --no-sign-request;
+    unzip opensc.pkg.zip;
+    sudo installer -verboseR -pkg opensc.pkg -target /;
     aws s3 cp s3://open-eid-digidoc4/cache/${TARGET}/${HASH}.zip ${HASH}.zip --no-sign-request;
     if [ $? -eq 0 ]; then
       unzip -qq -d /tmp ${HASH}.zip;

--- a/client/dialogs/SettingsDialog.cpp
+++ b/client/dialogs/SettingsDialog.cpp
@@ -180,7 +180,7 @@ void SettingsDialog::initUI()
 		b.exec();
 	});
 	connect(ui->btNavFromFile, &QPushButton::clicked, []{
-		Configuration::instance().update(true);
+		Configuration::instance().update();
 	});
 //#endif
 

--- a/qdigidoc4.wxs
+++ b/qdigidoc4.wxs
@@ -86,7 +86,7 @@ msiexec /a Eesti_ID_kaart-CPP-teek-arendajale-3.10.0.3672.BETA.msi /qn TARGETDIR
                 Directory="ProgramMenuDir" WorkingDirectory="APPLICATIONFOLDER"/>
             </File>
             <File Source="$(var.libs_path)\zlib1.dll"/>
-            <File Source="$(var.libs_path)\xerces-c_3_1.dll"/>
+            <File Source="$(var.libs_path)\xerces-c_3_2.dll"/>
 <?ifdef var.xalan ?>
             <File Source="$(var.libs_path)\XalanMessages_1_11.dll"/>
             <File Source="$(var.libs_path)\Xalan-C_1_11.dll"/>


### PR DESCRIPTION
- Update Xerces to 3.2 in Win installer
- Update libdigidocpp to 3.13.2 in Travis
- Use OpenSC latest build instead of esteid-pkcs11 in Travis
- Update qt-common to latest