### PR TITLE
AccessCert to use WarningDialog instead of QMessageBox

### DIFF
--- a/client/AccessCert.cpp
+++ b/client/AccessCert.cpp
@@ -31,7 +31,6 @@
 #include <QtCore/QFile>
 #include <QtCore/QStandardPaths>
 #include <QtNetwork/QSslKey>
-#include <QtWidgets/QLabel>
 
 #ifdef Q_OS_MAC
 #include <Security/Security.h>
@@ -45,15 +44,10 @@ public:
 };
 
 AccessCert::AccessCert( QWidget *parent )
-:	QMessageBox( parent )
+:	WarningDialog( "", parent )
 ,	d( new AccessCertPrivate )
 {
-	setIcon( Warning );
-	setStandardButtons( Ok );
-	setWindowTitle( tr("Server access certificate") );
-	setTextFormat( Qt::RichText );
-	if( QLabel *label = findChild<QLabel*>() )
-		label->setOpenExternalLinks( true );
+	setCancelText(::WarningDialog::tr("CLOSE"));
 #ifndef Q_OS_MAC
 	d->cert = Application::confValue( Application::PKCS12Cert ).toString();
 	d->pass = Application::confValue( Application::PKCS12Pass ).toString();

--- a/client/AccessCert.h
+++ b/client/AccessCert.h
@@ -19,12 +19,14 @@
 
 #pragma once
 
+#include "dialogs/WarningDialog.h"
+
 #include <QtWidgets/QMessageBox>
 
 class QSslCertificate;
 class QSslKey;
 class AccessCertPrivate;
-class AccessCert: public QMessageBox
+class AccessCert: public WarningDialog
 {
 	Q_OBJECT
 

--- a/client/dialogs/WarningDialog.cpp
+++ b/client/dialogs/WarningDialog.cpp
@@ -90,3 +90,9 @@ void WarningDialog::addButton(const QString& label, int ret)
 	connect(button, &QPushButton::clicked, [this, ret]() {done(ret);});
 	layout->insertWidget(buttonOffset++, button);
 }
+
+void WarningDialog::setText(const QString& text)
+{
+	ui->text->setText(text);
+	adjustSize();
+}

--- a/client/dialogs/WarningDialog.h
+++ b/client/dialogs/WarningDialog.h
@@ -37,6 +37,7 @@ public:
 
 	void addButton(const QString& label, int ret);
 	void setCancelText(const QString& label);
+	void setText(const QString& text);
 
 private:
 	Ui::WarningDialog *ui;

--- a/client/translations/ru.ts
+++ b/client/translations/ru.ts
@@ -31,8 +31,7 @@
     </message>
     <message>
         <source>You&apos;ve completed the free service limit - 10 signatures. Regarding to terms and conditions of validity confirmation service you&apos;re allowed to use the service in extent of 10 signatures per month. If you are going to exceed the limit of 10 signatures per month or/and will use the service for commercial purposes, please contact to IT support team of your company or sign a contract to use the &lt;a href=&quot;http://sk.ee/en/services/validity-confirmation-services&quot;&gt;service&lt;/a&gt;. Additional information is available &lt;a href=&quot;mailto:sales@sk.ee&quot;&gt;sales@sk.ee&lt;/a&gt; or phone (+372) 610 1892</source>
-        <translation>Вы использовали 10 бесплатных подписей. Согласно условиям использования услуги подтверждения действительности Вы можете поставить максимум 10 бесплатных подписей в течение месяца.
-Если Вам необходимо использовать услугу подтверждения действительности в большем объеме или в служебных целях, обратитесь в ИТ-отдел Вашей организации или заключите договор на использование &lt;a href=&quot;https://sk.ee/en/services/validity-confirmation-services&quot;&gt;услуги&lt;/a&gt;. Дополнительная информация: &lt;a href=&quot;mailto:sales@sk.ee&quot;&gt;sales@sk.ee&lt;/a&gt; или (+372) 610 1892</translation>
+        <translation>Вы использовали 10 бесплатных подписей. Согласно условиям использования услуги подтверждения действительности Вы можете поставить максимум 10 бесплатных подписей в течение месяца. Если Вам необходимо использовать услугу подтверждения действительности в большем объеме или в служебных целях, обратитесь в ИТ-отдел Вашей организации или заключите договор на использование &lt;a href=&quot;https://sk.ee/en/services/validity-confirmation-services&quot;&gt;услуги&lt;/a&gt;. Дополнительная информация: &lt;a href=&quot;mailto:sales@sk.ee&quot;&gt;sales@sk.ee&lt;/a&gt; или (+372) 610 1892</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
   1. AccessCert to use WarningDialog instead of QMessageBox.
   2. Fix text in Russian lang.

Signed-off-by: Oleg Prokofjev <oleg@aktors.ee>