### PR TITLE
Signature notice colors and smaller UI fixes

### DIFF
--- a/client/MainWindow.h
+++ b/client/MainWindow.h
@@ -41,6 +41,7 @@ class MainWindow;
 
 class CryptoDoc;
 class DigiDoc;
+class DocumentModel;
 
 class MainWindow : public QWidget
 {
@@ -71,6 +72,7 @@ protected:
 	void dragLeaveEvent( QDragLeaveEvent *event ) override;
 	void dropEvent( QDropEvent *event ) override;
 	void mousePressEvent(QMouseEvent *event) override;
+	void mouseReleaseEvent(QMouseEvent *event) override;
 	void resizeEvent( QResizeEvent *event ) override;
 
 private:
@@ -98,7 +100,10 @@ private:
 	void pinUnblock( QSmartCardData::PinType type, bool isForgotPin = false );
 	void pinPukChange( QSmartCardData::PinType type );
 	void removeAddress(int index);
+	void removeCryptoFile(int index);
+	bool removeFile(DocumentModel *model, int index);
 	void removeSignature(int index);
+	void removeSignatureFile(int index);
 	bool save();
 	QString selectFile( const QString &filename, bool fixedExt );
 	void selectPageIcon( PageIcon* page );

--- a/client/MainWindow.ui
+++ b/client/MainWindow.ui
@@ -122,6 +122,9 @@ min-width: 0px;
           <height>65</height>
          </size>
         </property>
+        <property name="cursor">
+         <cursorShape>PointingHandCursor</cursorShape>
+        </property>
         <property name="styleSheet">
          <string notr="true">background-color: #023565;
 background-color: #023565;</string>

--- a/client/dialogs/SignatureDialog.h
+++ b/client/dialogs/SignatureDialog.h
@@ -42,6 +42,7 @@ private:
 	void addItem( QTreeWidget *view, const QString &variable, const QString &value );
 	void addItem( QTreeWidget *view, const QString &variable, const QSslCertificate &cert );
 	void addItem( QTreeWidget *view, const QString &variable, const QUrl &url );
+	void decorateNotice(const QString color);
 
 	DigiDocSignature s;
 	Ui::SignatureDialog *d;

--- a/client/dialogs/SignatureDialog.ui
+++ b/client/dialogs/SignatureDialog.ui
@@ -111,13 +111,13 @@
           <widget class="QLabel" name="lblSigningCounty">
            <property name="minimumSize">
             <size>
-             <width>65</width>
+             <width>120</width>
              <height>16</height>
             </size>
            </property>
            <property name="maximumSize">
             <size>
-             <width>65</width>
+             <width>120</width>
              <height>16</height>
             </size>
            </property>
@@ -139,13 +139,13 @@
           <widget class="QLabel" name="lblSigningCity">
            <property name="minimumSize">
             <size>
-             <width>65</width>
+             <width>120</width>
              <height>16</height>
             </size>
            </property>
            <property name="maximumSize">
             <size>
-             <width>65</width>
+             <width>120</width>
              <height>16</height>
             </size>
            </property>
@@ -167,13 +167,13 @@
           <widget class="QLabel" name="lblSigningCountry">
            <property name="minimumSize">
             <size>
-             <width>65</width>
+             <width>120</width>
              <height>16</height>
             </size>
            </property>
            <property name="maximumSize">
             <size>
-             <width>65</width>
+             <width>120</width>
              <height>16</height>
             </size>
            </property>
@@ -329,13 +329,13 @@ background-color: #FFFFFF;</string>
           <widget class="QLabel" name="lblSigningZipCode">
            <property name="minimumSize">
             <size>
-             <width>65</width>
+             <width>120</width>
              <height>16</height>
             </size>
            </property>
            <property name="maximumSize">
             <size>
-             <width>65</width>
+             <width>120</width>
              <height>16</height>
             </size>
            </property>
@@ -495,6 +495,9 @@ background-color: #FFFFFF;</string>
            </property>
            <property name="openExternalLinks">
             <bool>true</bool>
+           </property>
+           <property name="textInteractionFlags">
+            <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
            </property>
           </widget>
          </item>
@@ -677,6 +680,9 @@ background-color: #f7f7f7;</string>
         </property>
         <property name="text">
          <string>TextLabel</string>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::AutoText</enum>
         </property>
        </widget>
       </item>

--- a/client/translations/en.ts
+++ b/client/translations/en.ts
@@ -1936,7 +1936,21 @@ DDOC is the old digital signature format. Nowadays you can view and verify docum
 ASiC-E is an international digital signature format that will be used across European countries.&lt;br /&gt;&lt;br /&gt;
 According to &lt;a href=&quot;http://sk.ee/en/services/validity-confirmation-services&quot;&gt;validity confirmation service standard conditions&lt;/a&gt; the digital signing service is free for 10 signatures per month. If you are going to exceed the limit of 10 signatures per month or/and will use the service for commercial purposes, please contact to IT support team of your company or sign a contract to use the service. Additional information is available &lt;a href=&quot;http://www.id.ee/?lang=en&quot;&gt;www.id.ee&lt;/a&gt; or ID-helpline 1777 (only from Estonia), (+372) 6773377.</translation>
     </message>
+    <message>
+        <source>You are about to delete the last file in the container, it is removed along with the container.</source>
+        <translation>You are about to delete the last file in the container, it is removed along with the container.</translation>
+    </message>
+    <message>
+        <source>CANCEL</source>
+        <translation>CANCEL</translation>
+    </message>
+    <message>
+        <source>REMOVE</source>
+        <translation>REMOVE</translation>
+    </message>
 </context>
+
+
 <context>
     <name>MobileDialog</name>
     <message>
@@ -2270,29 +2284,6 @@ Control code: %1</translation>
     <message>
         <source>is unknown</source>
         <translation>is unknown</translation>
-    </message>
-</context>
-<context>
-    <name>TreeWidget</name>
-    <message>
-        <source>Save file</source>
-        <translation>Save file</translation>
-    </message>
-    <message>
-        <source>Remove container</source>
-        <translation>Remove container</translation>
-    </message>
-    <message>
-        <source>You are about to delete the last file in the container, it is removed along with the container.</source>
-        <translation>You are about to delete the last file in the container, it is removed along with the container.</translation>
-    </message>
-    <message>
-        <source>Remove</source>
-        <translation>Remove</translation>
-    </message>
-    <message>
-        <source>Keep</source>
-        <translation>Keep</translation>
     </message>
 </context>
 <context>

--- a/client/translations/et.ts
+++ b/client/translations/et.ts
@@ -1905,7 +1905,21 @@ ASiC-E – rahvusvahelisele, Euroopa ülesele ühilduvusele suunatud tulevikuvor
 Vastavalt &lt;a href=&quot;https://sk.ee/teenused/kehtivuskinnituse-teenus/kehtivuskinnituse-teenuse-kasutamise-tavatingimused/&quot;&gt;kehtivuskinnitusteenuse kasutamise tavatingimustele&lt;/a&gt; on lubatud allkirjastamise teenust tasuta kasutada mahus kuni 10 allkirja kuus. Teenuse kasutamiseks suuremas mahus või kommertseesmärkidel pöörduge palun oma asutuse IT-meeskonna poole või sõlmige teenuse kasutamiseks leping. Lisainfo: &lt;a href=&quot;http://www.id.ee/?lang=et&quot;&gt;www.id.ee&lt;/a&gt; või ID-abiliini telefonil 1777 (vaid Eesti-siseselt), (+372) 6773377.
 </translation>
     </message>
+    <message>
+        <source>You are about to delete the last file in the container, it is removed along with the container.</source>
+        <translation>Oled kustutamas viimast faili ümbrikus, koos sellega eemaldatakse ka ümbrik.</translation>
+    </message>
+    <message>
+        <source>CANCEL</source>
+        <translation>KATKESTA</translation>
+    </message>
+    <message>
+        <source>REMOVE</source>
+        <translation>EEMALDA</translation>
+    </message>
 </context>
+
+
 <context>
     <name>MobileDialog</name>
     <message>
@@ -2239,29 +2253,6 @@ Kontrollkood: %1</translation>
     <message>
         <source>is unknown</source>
         <translation>on teadmata</translation>
-    </message>
-</context>
-<context>
-    <name>TreeWidget</name>
-    <message>
-        <source>Save file</source>
-        <translation>Salvesta fail</translation>
-    </message>
-    <message>
-        <source>Remove container</source>
-        <translation>Eemalda ümbrik</translation>
-    </message>
-    <message>
-        <source>You are about to delete the last file in the container, it is removed along with the container.</source>
-        <translation>Oled kustutamas viimast faili ümbrikus, koos sellega eemaldatakse ka ümbrik.</translation>
-    </message>
-    <message>
-        <source>Remove</source>
-        <translation>Eemalda</translation>
-    </message>
-    <message>
-        <source>Keep</source>
-        <translation>Loobu</translation>
     </message>
 </context>
 <context>

--- a/client/translations/ru.ts
+++ b/client/translations/ru.ts
@@ -1907,7 +1907,21 @@ DDOC – это ранее использовавшийся формат циф�
 ASiC-E – это разрабатываемый международный формат цифровой подписи, который будет использоваться в европейских государствах.&lt;br /&gt;&lt;br /&gt;
 Согласно &lt;a href=&quot;https://sk.ee/en/services/validity-confirmation-services/standard-conditions-of-validation-certification-service/&quot;&gt;условиям использования услуги подтверждения действительности&lt;/a&gt; Вы можете поставить максимум 10 бесплатных подписей в течение месяца. Если Вам необходимо использовать услугу подтверждения действительности в большем объеме или в служебных целях, обратитесь в ИТ-отдел Вашей организации или заключите договор на использование услуги. Дополнительная информация: &lt;a href=&quot;http://www.id.ee/?lang=ru&quot;&gt;www.id.ee&lt;/a&gt; или телефон линии помощи ID-карты 1777 (только в пределах Эстонии), (+372) 6773377.</translation>
     </message>
+    <message>
+        <source>You are about to delete the last file in the container, it is removed along with the container.</source>
+        <translation>Вы собираетесь удалить последний файл в контейнере, он удаляется вместе с контейнером.</translation>
+    </message>
+    <message>
+        <source>CANCEL</source>
+        <translation>ОТМЕНА</translation>
+    </message>
+    <message>
+        <source>REMOVE</source>
+        <translation>УДАЛИТЬ</translation>
+    </message>
 </context>
+
+
 <context>
     <name>MobileDialog</name>
     <message>
@@ -2243,29 +2257,8 @@ Kонтрольны код: %1</translation>
         <translation>неизвестно</translation>
     </message>
 </context>
-<context>
-    <name>TreeWidget</name>
-    <message>
-        <source>Save file</source>
-        <translation>Сохранить файл</translation>
-    </message>
-    <message>
-        <source>Remove container</source>
-        <translation>Удалить контейнер</translation>
-    </message>
-    <message>
-        <source>You are about to delete the last file in the container, it is removed along with the container.</source>
-        <translation>Вы собираетесь удалить последний файл в контейнере, он удаляется вместе с контейнером.</translation>
-    </message>
-    <message>
-        <source>Remove</source>
-        <translation>Удалить</translation>
-    </message>
-    <message>
-        <source>Keep</source>
-        <translation>Оставить</translation>
-    </message>
-</context>
+
+
 <context>
     <name>MainAction</name>
     <message>

--- a/client/widgets/ContainerPage.cpp
+++ b/client/widgets/ContainerPage.cpp
@@ -114,8 +114,8 @@ void ContainerPage::init()
 	connect(ui->cancel, &LabelButton::clicked, this, &ContainerPage::forward);
 	connect(ui->save, &LabelButton::clicked, this, &ContainerPage::forward);
 	connect(ui->leftPane, &FileList::addFiles, this, &ContainerPage::addFiles);
+	connect(ui->leftPane, &ItemList::removed, this, &ContainerPage::fileRemoved);
 	connect(ui->leftPane, &ItemList::addItem, this, &ContainerPage::forward);
-	connect(ui->leftPane, &ItemList::removed, this, &ContainerPage::removed);
 	connect(ui->rightPane, &ItemList::addItem, this, &ContainerPage::forward);
 	connect(ui->rightPane, &ItemList::removed, this, &ContainerPage::removed);
 	connect(ui->email, &LabelButton::clicked, this, &ContainerPage::forward);
@@ -155,6 +155,7 @@ void ContainerPage::hideMainAction()
 		mainAction->hide();
 	}
 	ui->mainActionSpacer->changeSize( 1, 20, QSizePolicy::Fixed );
+	ui->navigationArea->layout()->invalidate();
 }
 
 void ContainerPage::hideOtherAction()
@@ -280,7 +281,7 @@ void ContainerPage::showMainAction(Actions action)
 	}
 
 	ui->mainActionSpacer->changeSize( 198, 20, QSizePolicy::Fixed );
-	ui->navigationArea->adjustSize();
+	ui->navigationArea->layout()->invalidate();
 }
 
 void ContainerPage::showSigningButton()
@@ -396,7 +397,7 @@ void ContainerPage::updatePanes(ContainerState state)
 		showRightPane( ItemAddress, tr("Recipients") );
 		showMainAction(EncryptContainer);
 		ui->cancel->setText(tr("STARTING"));
-        ui->convert->setText(tr("SIGN"));
+		ui->convert->setText(tr("SIGN"));
 		showButtons( { ui->cancel, ui->convert } );
 		hideButtons( { ui->save, ui->navigateToContainer, ui->email } );
 		break;

--- a/client/widgets/ContainerPage.h
+++ b/client/widgets/ContainerPage.h
@@ -55,6 +55,7 @@ signals:
 	void action(int code, const QString &idCode = QString(), const QString &phoneNumber = QString());
 	void addFiles(const QStringList &files);
 	void cardChanged(const QString& idCode = QString());
+	void fileRemoved(int row);
 	void moved(const QString &to);	
 	void removed(int row);
 

--- a/client/widgets/FileList.cpp
+++ b/client/widgets/FileList.cpp
@@ -71,7 +71,7 @@ void FileList::remove(Item *item)
 {
 	int i;
 	if(documentModel && (i = index(item)) != -1)
-		documentModel->removeRows(i, 1);
+		emit removed(i);
 }
 
 void FileList::save(FileItem *item)


### PR DESCRIPTION
- Signature dialog: show signature restrictions and errors with colors
- Offer to remove file if last file is removed from container
- Navigate to start when pressed on coat of arms
- Button layout fixes in signature view (buttons not hidden below Sign)

Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>