### PR TITLE
Allow to re-sign documents and remove non-selfsigned signatures

### DIFF
--- a/client/MainWindow.h
+++ b/client/MainWindow.h
@@ -33,8 +33,6 @@
 #include <QImage>
 #include <QWidget>
 
-class DigiDoc;
-
 namespace Ui {
 class MainWindow;
 }
@@ -44,7 +42,7 @@ class DigiDoc;
 class DocumentModel;
 class WarningItem;
 class WarningRibbon;
-class WarningText;
+struct WarningText;
 
 class MainWindow : public QWidget
 {

--- a/client/dialogs/MobileProgress.cpp
+++ b/client/dialogs/MobileProgress.cpp
@@ -82,11 +82,11 @@ MobileProgress::MobileProgress( QWidget *parent )
 	taskbar->setWindow(parent->windowHandle());
 	taskbar->progress()->setRange(signProgressBar->minimum(), signProgressBar->maximum());
 	connect(statusTimer, &QTimeLine::frameChanged, taskbar->progress(), &QWinTaskbarProgress::setValue);
-    connect(cancel, &QPushButton::clicked, this, &MobileProgress::stop);
+	connect(cancel, &QPushButton::clicked, this, &MobileProgress::stop);
 #endif
 
-    cancel->setFont(Styles::font(Styles::Condensed, 14));
-    connect(cancel, &QPushButton::clicked, this, &MobileProgress::reject);
+	cancel->setFont(Styles::font(Styles::Condensed, 14));
+	connect(cancel, &QPushButton::clicked, this, &MobileProgress::reject);
 
 	manager = new QNetworkAccessManager( this );
 	connect(manager, &QNetworkAccessManager::finished, this, &MobileProgress::finished);
@@ -158,8 +158,8 @@ void MobileProgress::finished( QNetworkReply *reply )
 		{
 			code->setText( tr("Make sure control code matches with one in phone screen\n"
 				"and enter Mobile-ID PIN2-code.\nControl code: %1").arg( xml.readElementText() ) );
-            code->setAccessibleName( code->text() );
-            adjustSize();
+			code->setAccessibleName( code->text() );
+			adjustSize();
 		}
 		else if( xml.name() == "Sesscode" )
 			sessionCode = xml.readElementText();

--- a/client/dialogs/WarningDialog.cpp
+++ b/client/dialogs/WarningDialog.cpp
@@ -81,12 +81,21 @@ void WarningDialog::addButton(const QString& label, int ret)
 	auto layout = qobject_cast<QBoxLayout*>(ui->buttonBar->layout());
 	layout->insertSpacing(buttonOffset++, 35);
 
+	QFont font = Styles::font(Styles::Condensed, 14);
+	QFontMetrics fm(font);
+
 	QPushButton *button = new QPushButton(label, this);
-	button->setMinimumSize(120, 34);
+	button->setCursor(Qt::PointingHandCursor);
+	button->setFont(font);
+
+	int width = 120;
+	int textWidth = fm.width(label);
+	if(textWidth > 115)
+		width = textWidth + 16;
+	button->setMinimumSize(width, 34);
 	button->setStyleSheet("QPushButton {border-radius: 2px; border: none;color: #ffffff;background-color: #006EB5;}\nQPushButton:pressed {background-color: #41B6E6;} "
 		"QPushButton:hover:!pressed {background-color: #008DCF;}\nQPushButton:disabled {background-color: #BEDBED;}");
-	button->setCursor(Qt::PointingHandCursor);
-	button->setFont(Styles::font(Styles::Condensed, 14));
+
 	connect(button, &QPushButton::clicked, [this, ret]() {done(ret);});
 	layout->insertWidget(buttonOffset++, button);
 }

--- a/client/dialogs/WarningDialog.ui
+++ b/client/dialogs/WarningDialog.ui
@@ -69,7 +69,7 @@ background-color: #FFFFFF;</string>
       <cursorShape>IBeamCursor</cursorShape>
      </property>
      <property name="styleSheet">
-      <string notr="true">margin: 10px 15px 0px 15px;</string>
+      <string notr="true">margin: 10px 15px 0px 15px;  border: none;</string>
      </property>
      <property name="text">
       <string>TextLabel</string>
@@ -134,7 +134,7 @@ background-color: #FFFFFF;</string>
       <cursorShape>IBeamCursor</cursorShape>
      </property>
      <property name="styleSheet">
-      <string notr="true">margin: 0px 15px 0px 15px;</string>
+      <string notr="true">margin: 0px 15px 0px 15px; border: none;</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
@@ -163,6 +163,9 @@ background-color: #FFFFFF;</string>
        <width>16777215</width>
        <height>45</height>
       </size>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">border: none;</string>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <property name="leftMargin">

--- a/client/translations/en.ts
+++ b/client/translations/en.ts
@@ -549,6 +549,18 @@ Learn more info here:</translation>
         <source>time</source>
         <translation>time</translation>
     </message>
+    <message>
+        <source>Remove signature %1</source>
+        <translation>Remove signature %1</translation>
+    </message>
+    <message>
+        <source>CANCEL</source>
+        <translation>CANCEL</translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
 </context>
 
 
@@ -958,6 +970,18 @@ Learn more info here:</translation>
     <message>
         <source>Mobile-ID user certificates are revoked or suspended.</source>
         <translation>Mobile-ID user certificates are revoked or suspended.</translation>
+    </message>
+    <message>
+        <source>Make sure control code matches with one in phone screen
+and enter Mobile-ID PIN2-code.
+Control code: %1</source>
+        <translation>Make sure control code matches with one in phone screen
+and enter Mobile-ID PIN2-code.
+Control code: %1</translation>
+    </message>
+    <message>
+        <source>SSL handshake failed. Check the proxy settings of your computer or software upgrades.</source>
+        <translation>SSL handshake failed. Check the proxy settings of your computer or software upgrades.</translation>
     </message>
 </context>
 
@@ -1405,6 +1429,14 @@ then the only way to get an ID card is to turn to work&lt;br&gt;
     <message>
         <source>More information</source>
         <translation>More information</translation>
+    </message>
+    <message>
+        <source>The document has already been signed by you.</source>
+        <translation>The document has already been signed by you.</translation>
+    </message>
+    <message>
+        <source>CONTINUE SIGNING</source>
+        <translation>CONTINUE SIGNING</translation>
     </message>
 </context>
 
@@ -2122,14 +2154,6 @@ New ID-cards have chip on the back side of the card.</translation>
         <translation>Personal code</translation>
     </message>
     <message>
-        <source>Continue signing</source>
-        <translation>Continue signing</translation>
-    </message>
-    <message>
-        <source>The document has already been signed by you.</source>
-        <translation>The document has already been signed by you.</translation>
-    </message>
-    <message>
         <source>Signing not allowed.</source>
         <translation>Signing not allowed.</translation>
     </message>
@@ -2275,14 +2299,6 @@ According to &lt;a href=&quot;http://sk.ee/en/services/validity-confirmation-ser
         <translation>Sign</translation>
     </message>
     <message>
-        <source>Make sure control code matches with one in phone screen
-and enter Mobile-ID PIN2-code.
-Control code: %1</source>
-        <translation>Make sure control code matches with one in phone screen
-and enter Mobile-ID PIN2-code.
-Control code: %1</translation>
-    </message>
-    <message>
         <source>Not allowed to use OCSP service!&lt;br/&gt;Please check your server access certificate.</source>
         <translation>Not allowed to use OCSP service!&lt;br/&gt;Please check your server access certificate.</translation>
     </message>
@@ -2297,10 +2313,6 @@ Control code: %1</translation>
     <message>
         <source>Your Mobile-ID service is not activated.</source>
         <translation>Your Mobile-ID service is not activated.</translation>
-    </message>
-    <message>
-        <source>SSL handshake failed. Check the proxy settings of your computer or software upgrades.</source>
-        <translation>SSL handshake failed. Check the proxy settings of your computer or software upgrades.</translation>
     </message>
     <message>
         <source>Invalid phone number! Please include correct country code.</source>
@@ -2480,69 +2492,8 @@ Control code: %1</translation>
         <translation>Failed to decrypt document</translation>
     </message>
 </context>
-<context>
-    <name>SignatureWidget</name>
-    <message>
-        <source>Show details</source>
-        <translation>Show details</translation>
-    </message>
-    <message>
-        <source>Remove</source>
-        <translation>Remove</translation>
-    </message>
-    <message>
-        <source>Signed on</source>
-        <translation>Signed on</translation>
-    </message>
-    <message>
-        <source>time</source>
-        <translation>time</translation>
-    </message>
-    <message>
-        <source>Test signature</source>
-        <translation>Test signature</translation>
-    </message>
-    <message>
-        <source>Remove signature %1</source>
-        <translation>Remove signature %1</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Location</translation>
-    </message>
-    <message>
-        <source>Role</source>
-        <translation>Role</translation>
-    </message>
-    <message>
-        <source>Signature</source>
-        <translation>Signature</translation>
-    </message>
-    <message>
-        <source>Warnings</source>
-        <translation>Warnings</translation>
-    </message>
-    <message>
-        <source>Restrictions</source>
-        <translation>Restrictions</translation>
-    </message>
-    <message>
-        <source>Timestamp</source>
-        <translation>Timestamp</translation>
-    </message>
-    <message>
-        <source>is valid</source>
-        <translation>is valid</translation>
-    </message>
-    <message>
-        <source>is not valid</source>
-        <translation>is not valid</translation>
-    </message>
-    <message>
-        <source>is unknown</source>
-        <translation>is unknown</translation>
-    </message>
-</context>
+
+
 <context>
     <name>MainAction</name>
     <message>

--- a/client/translations/et.ts
+++ b/client/translations/et.ts
@@ -546,6 +546,18 @@ Rohkem infot leiate siit:</translation>
         <source>time</source>
         <translation>kell</translation>
     </message>
+    <message>
+        <source>Remove signature %1</source>
+        <translation>Eemalda allkiri %1</translation>
+    </message>
+    <message>
+        <source>CANCEL</source>
+        <translation>KATKESTA</translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
 </context>
 
 <context>
@@ -953,6 +965,18 @@ Rohkem infot leiate siit:</translation>
     <message>
         <source>Mobile-ID user certificates are revoked or suspended.</source>
         <translation>Kasutaja Mobiil-ID sertifikaadid on tühistatud või peatatud.</translation>
+    </message>
+    <message>
+        <source>Make sure control code matches with one in phone screen
+and enter Mobile-ID PIN2-code.
+Control code: %1</source>
+        <translation>Veendu kontrollkoodi õigsuses
+ja sisesta telefonil Mobiil-ID PIN2-kood.
+Kontrollkood: %1</translation>
+    </message>
+    <message>
+        <source>SSL handshake failed. Check the proxy settings of your computer or software upgrades.</source>
+        <translation>SSL ühenduskanali loomine ebaõnnestus. Kontrolli arvuti puhverserveri seadeid või tarkvara uuendusi.</translation>
     </message>
 </context>
 
@@ -1397,6 +1421,14 @@ järel, siis ainus võimalus ID-kaart tööle saada on pöörduda&lt;br&gt;
     <message>
         <source>More information</source>
         <translation>Rohkem infot</translation>
+    </message>
+    <message>
+        <source>The document has already been signed by you.</source>
+        <translation>Dokument on sinu poolt juba allkirjastatud.</translation>
+    </message>
+    <message>
+        <source>CONTINUE SIGNING</source>
+        <translation>JÄTKA ALLKIRJASTAMISEGA</translation>
     </message>
 </context>
 
@@ -2099,14 +2131,6 @@ Uutel ID-kaartidel on kiip kaardi tagumisel küljel.</translation>
         <translation>Digitaalallkirjade kinnituslehe kuvamiseks peab olema arvutis vähemalt üks printer seadistatud!</translation>
     </message>
     <message>
-        <source>Continue signing</source>
-        <translation>Jätka allkirjastamisega</translation>
-    </message>
-    <message>
-        <source>The document has already been signed by you.</source>
-        <translation>Dokument on sinu poolt juba allkirjastatud.</translation>
-    </message>
-    <message>
         <source>Signing not allowed.</source>
         <translation>Allkirja andmine ei ole lubatud.</translation>
     </message>
@@ -2253,14 +2277,6 @@ Vastavalt &lt;a href=&quot;https://sk.ee/teenused/kehtivuskinnituse-teenus/kehti
         <translation>Allkirjastan</translation>
     </message>
     <message>
-        <source>Make sure control code matches with one in phone screen
-and enter Mobile-ID PIN2-code.
-Control code: %1</source>
-        <translation>Veendu kontrollkoodi õigsuses
-ja sisesta telefonil Mobiil-ID PIN2-kood.
-Kontrollkood: %1</translation>
-    </message>
-    <message>
         <source>Not allowed to use OCSP service!&lt;br/&gt;Please check your server access certificate.</source>
         <translation>Puudub juurdepääs OCSP teenusele!&lt;br/&gt;Palun kontrollige juurdepääsutõendi olemasolu.</translation>
     </message>
@@ -2275,10 +2291,6 @@ Kontrollkood: %1</translation>
     <message>
         <source>Your Mobile-ID service is not activated.</source>
         <translation>Mobiil-ID sertifikaadid ei ole aktiveeritud.</translation>
-    </message>
-    <message>
-        <source>SSL handshake failed. Check the proxy settings of your computer or software upgrades.</source>
-        <translation>SSL ühenduskanali loomine ebaõnnestus. Kontrolli arvuti puhverserveri seadeid või tarkvara uuendusi.</translation>
     </message>
     <message>
         <source>Invalid phone number! Please include correct country code.</source>
@@ -2458,69 +2470,8 @@ Kontrollkood: %1</translation>
         <translation type="unfinished"></translation>
     </message>
 </context>
-<context>
-    <name>SignatureWidget</name>
-    <message>
-        <source>Show details</source>
-        <translation>Vaata üksikasju</translation>
-    </message>
-    <message>
-        <source>Remove</source>
-        <translation>Eemalda</translation>
-    </message>
-    <message>
-        <source>Signed on</source>
-        <translation>Allkirjastati</translation>
-    </message>
-    <message>
-        <source>time</source>
-        <translation>kell</translation>
-    </message>
-    <message>
-        <source>Test signature</source>
-        <translation>Test allkiri</translation>
-    </message>
-    <message>
-        <source>Remove signature %1</source>
-        <translation>Eemalda allkiri %1</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation>Asukoht</translation>
-    </message>
-    <message>
-        <source>Role</source>
-        <translation>Roll</translation>
-    </message>
-    <message>
-        <source>Signature</source>
-        <translation>Allkiri</translation>
-    </message>
-    <message>
-        <source>Warnings</source>
-        <translation>hoiatusega</translation>
-    </message>
-    <message>
-        <source>Restrictions</source>
-        <translation>piirangud</translation>
-    </message>
-    <message>
-        <source>Timestamp</source>
-        <translation>Ajatempel</translation>
-    </message>
-    <message>
-        <source>is valid</source>
-        <translation>on kehtiv</translation>
-    </message>
-    <message>
-        <source>is not valid</source>
-        <translation>ei ole kehtiv</translation>
-    </message>
-    <message>
-        <source>is unknown</source>
-        <translation>on teadmata</translation>
-    </message>
-</context>
+
+
 <context>
     <name>MainAction</name>
     <message>

--- a/client/translations/ru.ts
+++ b/client/translations/ru.ts
@@ -548,6 +548,18 @@ Learn more info here:</source>
         <source>time</source>
         <translation>время</translation>
     </message>
+    <message>
+        <source>Remove signature %1</source>
+        <translation>Удалить подпись %1</translation>
+    </message>
+    <message>
+        <source>CANCEL</source>
+        <translation>ОТМЕНА</translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
 </context>
 
 
@@ -956,6 +968,18 @@ Learn more info here:</source>
     <message>
         <source>Mobile-ID user certificates are revoked or suspended.</source>
         <translation>Сертификаты Mobiil-ID признаны не действительными или их действие приостановлено.</translation>
+    </message>
+    <message>
+        <source>Make sure control code matches with one in phone screen
+and enter Mobile-ID PIN2-code.
+Control code: %1</source>
+        <translation>Убедитесь в правильности контрольного кодa
+и введите PIN2-код для Mobiil-ID.
+Kонтрольны код: %1</translation>
+    </message>
+    <message>
+        <source>SSL handshake failed. Check the proxy settings of your computer or software upgrades.</source>
+        <translation>Не удалось создать SSL канал передачи данных. Проверьте настройки буферного сервера компьютера или обновления программного обеспечения.</translation>
     </message>
 </context>
 
@@ -1395,6 +1419,14 @@ PIN1 или PIN2. Тогда, для получения новых кодов с
     <message>
         <source>More information</source>
         <translation>Дополнительная информация</translation>
+    </message>
+    <message>
+        <source>The document has already been signed by you.</source>
+        <translation>Вы уже подписали этот документ.</translation>
+    </message>
+    <message>
+        <source>CONTINUE SIGNING</source>
+        <translation>ПОДПИСАТЬ</translation>
     </message>
 </context>
 
@@ -2098,14 +2130,6 @@ New ID-cards have chip on the back side of the card.</source>
         <translation>Для отображения листа подтверждения действительности цифровой подписи на компьютере должен быть установлен как минимум один принтер!</translation>
     </message>
     <message>
-        <source>Continue signing</source>
-        <translation>Подписать</translation>
-    </message>
-    <message>
-        <source>The document has already been signed by you.</source>
-        <translation>Вы уже подписали этот документ.</translation>
-    </message>
-    <message>
         <source>Signing not allowed.</source>
         <translation>Подпись невозможна.</translation>
     </message>
@@ -2259,14 +2283,6 @@ ASiC-E – это разрабатываемый международный фо
         <translation>Подписать</translation>
     </message>
     <message>
-        <source>Make sure control code matches with one in phone screen
-and enter Mobile-ID PIN2-code.
-Control code: %1</source>
-        <translation>Убедитесь в правильности контрольного кодa
-и введите PIN2-код для Mobiil-ID.
-Kонтрольны код: %1</translation>
-    </message>
-    <message>
         <source>Not allowed to use OCSP service!&lt;br/&gt;Please check your server access certificate.</source>
         <translation>Не разрешено использовать OCSP услугу!&lt;br/&gt;Пожалуйста проверьте действительность справки доступа.</translation>
     </message>
@@ -2281,10 +2297,6 @@ Kонтрольны код: %1</translation>
     <message>
         <source>Your Mobile-ID service is not activated.</source>
         <translation>Не активирована услуга Mobiil-ID.</translation>
-    </message>
-    <message>
-        <source>SSL handshake failed. Check the proxy settings of your computer or software upgrades.</source>
-        <translation>Не удалось создать SSL канал передачи данных. Проверьте настройки буферного сервера компьютера или обновления программного обеспечения.</translation>
     </message>
     <message>
         <source>Invalid phone number! Please include correct country code.</source>
@@ -2462,69 +2474,6 @@ Kонтрольны код: %1</translation>
     <message>
         <source>Failed to decrypt document</source>
         <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>SignatureWidget</name>
-    <message>
-        <source>Signed on</source>
-        <translation>Подписано</translation>
-    </message>
-    <message>
-        <source>Show details</source>
-        <translation>Подробнее</translation>
-    </message>
-    <message>
-        <source>Remove</source>
-        <translation>Удалить</translation>
-    </message>
-    <message>
-        <source>time</source>
-        <translation>Время</translation>
-    </message>
-    <message>
-        <source>Test signature</source>
-        <translation>Пробная подпись</translation>
-    </message>
-    <message>
-        <source>Remove signature %1</source>
-        <translation>Удалить подпись %1</translation>
-    </message>
-    <message>
-        <source>Location</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Role</source>
-        <translation>Роль</translation>
-    </message>
-    <message>
-        <source>Signature</source>
-        <translation>Подпись</translation>
-    </message>
-    <message>
-        <source>Warnings</source>
-        <translation>предупреждения</translation>
-    </message>
-    <message>
-        <source>Restrictions</source>
-        <translation>oгрaничения</translation>
-    </message>
-    <message>
-        <source>Timestamp</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>is valid</source>
-        <translation>действительна</translation>
-    </message>
-    <message>
-        <source>is not valid</source>
-        <translation>недействительна</translation>
-    </message>
-    <message>
-        <source>is unknown</source>
-        <translation>неизвестно</translation>
     </message>
 </context>
 

--- a/client/widgets/ContainerPage.cpp
+++ b/client/widgets/ContainerPage.cpp
@@ -133,6 +133,19 @@ void ContainerPage::init()
 
 void ContainerPage::forward(int code)
 {
+	if(code & (SignatureAdd | SignatureMobile))
+	{
+		if(ui->rightPane->hasItem(
+			[this](Item* const item) -> bool
+			{
+				auto signatureItem = qobject_cast<SignatureItem* const>(item);
+				return signatureItem && signatureItem->isSelfSigned(cardInReader, mobileCode);
+			}
+		))
+		{
+			// TODO
+		}
+	}
 	emit action(code);
 }
 
@@ -350,8 +363,6 @@ void ContainerPage::transition(DigiDoc* container)
 					.arg(tr("More information")));
 		}
 		ui->rightPane->addWidget(item);
-		if(enableSigning && item->isSelfSigned(cardInReader, mobileCode))
-			enableSigning = false;
 	}
 
 	if(enableSigning)

--- a/client/widgets/ContainerPage.cpp
+++ b/client/widgets/ContainerPage.cpp
@@ -24,6 +24,7 @@
 #include "Settings.h"
 #include "Styles.h"
 #include "dialogs/MobileDialog.h"
+#include "dialogs/WarningDialog.h"
 #include "widgets/AddressItem.h"
 #include "widgets/FileItem.h"
 #include "widgets/SignatureItem.h"
@@ -133,7 +134,7 @@ void ContainerPage::init()
 
 void ContainerPage::forward(int code)
 {
-	if(code & (SignatureAdd | SignatureMobile))
+	if(code == SignatureAdd || code == SignatureMobile)
 	{
 		if(ui->rightPane->hasItem(
 			[this](Item* const item) -> bool
@@ -143,7 +144,11 @@ void ContainerPage::forward(int code)
 			}
 		))
 		{
-			// TODO
+			WarningDialog dlg(tr("The document has already been signed by you."), this);
+			dlg.addButton(tr("CONTINUE SIGNING"), SignatureAdd);
+			dlg.exec();
+			if(dlg.result() != SignatureAdd)
+				return;
 		}
 	}
 	emit action(code);
@@ -372,18 +377,6 @@ void ContainerPage::transition(DigiDoc* container)
 
 	ui->leftPane->setModel(container->documentModel());
 	updatePanes(state);
-
-	// TODO Show invalid signature status
-	// switch( status )
-	// {
-	// case DigiDocSignature::Invalid: viewSignaturesError->setText( tr("NB! Invalid signature") ); break;
-	// case DigiDocSignature::Unknown: viewSignaturesError->setText( "<i>" + tr("NB! Status unknown") + "</i>" ); break;
-	// case DigiDocSignature::Test: viewSignaturesError->setText( tr("NB! Test signature") ); break;
-	// case DigiDocSignature::Warning: viewSignaturesError->setText( "<font color=\"#FFB366\">" + tr("NB! Signature contains warnings") + "</font>" ); break;
-	// case DigiDocSignature::NonQSCD: viewSignaturesError->clear(); break;
-	// case DigiDocSignature::Valid: viewSignaturesError->clear(); break;
-	// }
-	// break;
 }
 
 void ContainerPage::updatePanes(ContainerState state)

--- a/client/widgets/ContainerPage.h
+++ b/client/widgets/ContainerPage.h
@@ -66,6 +66,7 @@ protected:
 
 private:
 	void changeCard(const QString& idCode);
+	bool checkAction(int code, const QString& selectedCard, const QString& selectedMobile);
 	void clear();
 	void elideFileName(bool force = false);
 	void forward(int code);

--- a/client/widgets/ItemList.cpp
+++ b/client/widgets/ItemList.cpp
@@ -149,7 +149,7 @@ void ItemList::details(const QString &id)
 	}
 }
 
-ContainerState ItemList::getState() { return state; }
+ContainerState ItemList::getState() const { return state; }
 
 int ItemList::index(Item *item) const
 {
@@ -158,6 +158,17 @@ int ItemList::index(Item *item) const
 		return std::distance(items.begin(), it);
 
 	return -1;
+}
+
+bool ItemList::hasItem(std::function<bool(Item* const)> cb)
+{
+	for(auto item: items)
+	{
+		if(cb(item))
+			return true;
+	}
+
+	return false;
 }
 
 void ItemList::init(ItemType item, const QString &header, bool hideFind)

--- a/client/widgets/ItemList.h
+++ b/client/widgets/ItemList.h
@@ -22,6 +22,7 @@
 #include "common_enums.h"
 #include "widgets/Item.h"
 
+#include <functional>
 #include <QWidget>
 
 namespace Ui {
@@ -43,7 +44,8 @@ public:
 	void addHeaderWidget(Item *widget);
 	void addWidget(Item *widget);
 	void clear();
-	ria::qdigidoc4::ContainerState getState();
+	ria::qdigidoc4::ContainerState getState() const;
+	bool hasItem(std::function<bool(Item* const)> cb);
 	void removeItem(int row);
 	void stateChange(ria::qdigidoc4::ContainerState state);
 

--- a/client/widgets/SignatureItem.h
+++ b/client/widgets/SignatureItem.h
@@ -35,11 +35,10 @@ class SignatureItem : public Item
 	Q_OBJECT
 
 public:
-	explicit SignatureItem(const DigiDocSignature &s, ria::qdigidoc4::ContainerState state, QWidget *parent = nullptr);
+	explicit SignatureItem(const DigiDocSignature &s, ria::qdigidoc4::ContainerState state, bool isSupported, QWidget *parent = nullptr);
 	~SignatureItem();
 
 	QString id() const override;
-	void idChanged(const QString& cardCode, const QString& mobileCode) override;
 	bool isInvalid() const;
 	bool isSelfSigned(const QString& cardCode, const QString& mobileCode) const;
 
@@ -56,6 +55,7 @@ private:
 	void init();
 	void recalculate();
 	QString red(const QString &text);
+	void removeSignature();
 	void setIcon(const QString &icon, int width = 17, int height = 20);
 
 	Ui::SignatureItem *ui;


### PR DESCRIPTION
- Mobile dialog translations
- Add signature to self-signed document (warn instead of disabling)
- Allow to remove also non-selfsigned signatures

Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>