### PR TITLE
Fix for errors/tickets

### DIFF
--- a/client/MainWindow.h
+++ b/client/MainWindow.h
@@ -33,6 +33,10 @@
 #include <QImage>
 #include <QWidget>
 
+#define UPDATE_CERT_WARNING "updateCertificateEnabled"
+#define UNBLOCK_PIN1_WARNING "unBlockPIN1"
+#define UNBLOCK_PIN2_WARNING "unBlockPIN2"
+
 namespace Ui {
 class MainWindow;
 }
@@ -81,7 +85,7 @@ protected:
 private:
 	void cachePicture( const QString &id, const QImage &image );
 	void browseOnDisk(const QString &fileName);
-	void clearCertWarning();
+	void clearWarning(const char* warningIdent);
 	void clearOverlay();
 	bool closeWarning(WarningItem *warning, bool force = false);
 	void closeWarnings(int page);
@@ -133,6 +137,7 @@ private:
 	bool validateFiles(const QString &container, const QStringList &files);
 	void showUpdateCertWarning();
 	void showIdCardAlerts(const QSmartCardData& t);
+	void showPinBlockedWarning(const QSmartCardData& t);
 	bool wrapContainer();
 	
 	CryptoDoc* cryptoDoc = nullptr;

--- a/client/MainWindow_MyEID.cpp
+++ b/client/MainWindow_MyEID.cpp
@@ -87,6 +87,11 @@ void MainWindow::pinUnblock( QSmartCardData::PinType type, bool isForgotPin )
 				smartcard->data().retryCount( QSmartCardData::Pin1Type ) == 0 || 
 				smartcard->data().retryCount( QSmartCardData::Pin2Type ) == 0 || 
 				smartcard->data().retryCount( QSmartCardData::PukType ) == 0 );
+
+		if (type == QSmartCardData::Pin1Type)
+			clearWarning(UNBLOCK_PIN1_WARNING);
+		if (type == QSmartCardData::Pin2Type)
+			clearWarning(UNBLOCK_PIN2_WARNING);
 	}
 }
 
@@ -99,6 +104,8 @@ void MainWindow::pinPukChange( QSmartCardData::PinType type )
 			.arg( QSmartCardData::typeString( type ) ), true );
 		ui->accordion->updateInfo( smartcard );
 	}
+    else
+    	showPinBlockedWarning( smartcard->data() );
 }
 
 void MainWindow::certDetailsClicked( const QString &link )

--- a/client/QSmartCard.cpp
+++ b/client/QSmartCard.cpp
@@ -463,8 +463,8 @@ QSmartCard::ErrorType QSmartCard::pinChange(QSmartCardData::PinType type)
 		oldPin = p->firstCodeText().toUtf8();
 		newPin = p->newCodeText().toUtf8();
 	}
-	title = tr("Changing %1 code").arg(QSmartCardData::typeString(type));
-	textBody = tr("PinPad lugejaga %1 muutmiseks<br />tuleb kõigepealt sisestada vana %1 ning siis kaks korda uus %1.").arg(QSmartCardData::typeString(type));
+	title = tr("%1 code change").arg(QSmartCardData::typeString(type));
+	textBody = tr("To change %1 on a PinPad reader the old %1 code has to be entered first and then the new %1 code twice.").arg(QSmartCardData::typeString(type));
 
 	return change(type, newPin, oldPin, title, textBody);
 }
@@ -483,11 +483,11 @@ QSmartCard::ErrorType QSmartCard::pinUnblock(QSmartCardData::PinType type, bool 
 		puk = p->firstCodeText().toUtf8();
 		newPin = p->newCodeText().toUtf8();
 	}
-	title = tr("Unblocking %1 code").arg(QSmartCardData::typeString(type));
+	title = tr("%1 unblocking").arg(QSmartCardData::typeString(type));
 	textBody = (isForgotPin) ?  
-		tr("PinPad lugejaga %1 muutmiseks tuleb kõigepealt<br />sisestada PUK ning siis kaks korda %1.").arg(QSmartCardData::typeString(type))
+		tr("To change %1 code with the PUK code on a PinPad reader the PUK code has to be entered first and then the %1 code twice.").arg(QSmartCardData::typeString(type))
     	:
-		tr("PinPad lugejaga %1 blokeeringu tühistamiseks<br />tuleb kõigepealt sisestada PUK ning siis kaks korda %1.").arg(QSmartCardData::typeString(type));
+		tr("To unblock the %1 code on a PinPad reader the PUK code has to be entered first and then the %1 code twice.").arg(QSmartCardData::typeString(type));
 
 	return unblock(type, newPin, puk, title, textBody);
 }

--- a/client/translations/en.ts
+++ b/client/translations/en.ts
@@ -2648,4 +2648,19 @@ ID-CARD</translation>
         <translation>Less</translation>
     </message>
 </context>
+<context>
+    <name>QSmartCard</name>
+    <message>
+        <source>To change %1 on a PinPad reader the old %1 code has to be entered first and then the new %1 code twice.</source>
+        <translation>To change %1 on a PinPad reader the old %1 code&lt;br&gt;has to be entered first and then the new %1 code twice.</translation>
+    </message>
+    <message>
+        <source>To change %1 code with the PUK code on a PinPad reader the PUK code has to be entered first and then the %1 code twice.</source>
+        <translation>To change %1 code with the PUK code on a PinPad reader&lt;br&gt;the PUK code has to be entered first and then the %1 code twice.</translation>
+    </message>
+    <message>
+        <source>To unblock the %1 code on a PinPad reader the PUK code has to be entered first and then the %1 code twice.</source>
+        <translation>To unblock the %1 code on a PinPad reader the PUK&lt;br&gt;code has to be entered first and then the %1 code twice.</translation>
+    </message>
+</context>
 </TS>

--- a/client/translations/en.ts
+++ b/client/translations/en.ts
@@ -418,6 +418,10 @@ Media type: %3</translation>
         <translation>Container's signatures</translation>
     </message>
     <message>
+        <source>Container's timestamps</source>
+        <translation>Container's timestamps</translation>
+    </message>
+    <message>
         <source>Recipients</source>
         <translation>Recipients</translation>
     </message>
@@ -1151,8 +1155,8 @@ here you can set a new PIN1 code.&lt;/li&gt;
         <source>ConditionsUnlockPIN2</source>
         <translation>&lt;ul&gt;
 &lt;li&gt;To unblock PIN2, enter the PUK code for the card.&lt;/li&gt;
-&lt;li&gt;You can find the PUK code from the ID-card in the code box, if you do not&lt;br&gt;
-in the meantime changed&lt;/li&gt;
+&lt;li&gt;You can find the PUK code from the ID-card in the code box,&lt;br&gt;
+if you do not in the meantime changed&lt;/li&gt;
 &lt;li&gt;If you do not know your PUK code for your ID card, please visit&lt;br&gt;
 a customer service point where you can get a new code container.&lt;/li&gt;
 &lt;/ul&gt;</translation>
@@ -1162,8 +1166,8 @@ a customer service point where you can get a new code container.&lt;/li&gt;
         <translation>
 &lt;ul&gt;
 &lt;li&gt;To unblock PIN1, enter the PUK code for the card.&lt;/li&gt;
-&lt;li&gt;You can find the PUK code from the ID-card in the code box, if you do not&lt;br&gt;
-in the meantime changed&lt;/li&gt;
+&lt;li&gt;You can find the PUK code from the ID-card in the code box,&lt;br&gt;
+if you do not in the meantime changed&lt;/li&gt;
 &lt;li&gt;If you do not know your PUK code for your ID card, please visit&lt;br&gt;
 a customer service point where you can get a new code container.&lt;/li&gt;
 &lt;/ul&gt;</translation>
@@ -1175,27 +1179,26 @@ a customer service point where you can get a new code container.&lt;/li&gt;
 &lt;li&gt;The PIN2 code is used to give a digital signature.&lt;/li&gt;
 &lt;li&gt;If you enter the PIN2 code incorrectly three times, then signing&lt;br&gt;
 the certificate will be blocked and the ID card will not be possible&lt;br&gt;
-to use before signing&lt;br&gt;
-PUK koodiga.&lt;/li&gt;
+to use, until it is unblocked via the PUK code.&lt;/li&gt;
 &lt;/ul&gt;</translation>
     </message>
     <message>
         <source>ConditionsChangePIN1</source>
         <translation>&lt;ul&gt;
 &lt;li&gt;New PIN1 must be different from the previous one.&lt;/li&gt;
-&lt;li&gt;The PIN1 code is used for identity verification&lt;br&gt;
-for access.&lt;/li&gt;
-&lt;li&gt;If you enter the PIN1 code incorrectly three times, then you will receive a personal identification&lt;br&gt;
-The certificate is blocked and you can only use the ID card after&lt;br&gt;
-unblock with PUK.&lt;/li&gt;
+&lt;li&gt;The PIN1 code is used for identity verification for access.&lt;/li&gt;
+&lt;li&gt;If you enter the PIN1 code incorrectly three times,then&lt;br&gt;
+a personal identification certificate will be blocked and the ID card&lt;br&gt;
+will not be possible to use to verify identification, until it is&lt;br&gt;
+unblocked via the PUK code.&lt;/li&gt;
 &lt;/ul&gt;</translation>
     </message>
     <message>
         <source>ConditionsChangePUK</source>
         <translation>&lt;ul&gt;
 &lt;li&gt;If the PUK code goes away after changing the code, and&lt;br&gt;
-the certificate will be blocked by entering three incorrect PIN1 or PIN2&lt;br&gt;
-then the only way to get an ID card is to turn to work&lt;br&gt;
+the certificate will be blocked by entering three incorrect PIN1 or&lt;br&gt;
+PIN2 then the only way to get an ID card is to turn to work&lt;br&gt;
 &lt;u&gt;customer service point&lt;/u&gt;.&lt;/li&gt;
 &lt;li&gt;Your PUK code is located in the envelope.&lt;/li&gt;
 &lt;/ul&gt;</translation>
@@ -1470,10 +1473,6 @@ then the only way to get an ID card is to turn to work&lt;br&gt;
     <message>
         <source>SAVE WITHOUT SIGNING</source>
         <translation>SAVE WITHOUT SIGNING</translation>
-    </message>
-    <message>
-        <source>Container's timestamps</source>
-        <translation>Container's timestamps</translation>
     </message>
     <message>
         <source>NB! Invalid signature</source>

--- a/client/translations/et.ts
+++ b/client/translations/et.ts
@@ -416,6 +416,10 @@ Tüüp: %3</translation>
         <translation>Konteineri allkirjad</translation>
     </message>
     <message>
+        <source>Container's timestamps</source>
+        <translation>Konteineri ajatemplid</translation>
+    </message>
+    <message>
         <source>Recipients</source>
         <translation>Adressaadid</translation>
     </message>
@@ -1201,7 +1205,7 @@ järel, siis ainus võimalus ID-kaart tööle saada on pöörduda&lt;br&gt;
     </message>
     <message>
         <source>%1 code change</source>
-        <translation>%1 koodi vahetamin</translation>
+        <translation>%1 koodi vahetamine</translation>
     </message>
     <message>
         <source>VALID %1 CODE</source>
@@ -1461,10 +1465,6 @@ järel, siis ainus võimalus ID-kaart tööle saada on pöörduda&lt;br&gt;
     <message>
         <source>SAVE WITHOUT SIGNING</source>
         <translation>SALVESTA ALLKIRJASTAMATA</translation>
-    </message>
-    <message>
-        <source>Container's timestamps</source>
-        <translation>Konteineri ajatemplid</translation>
     </message>
     <message>
         <source>NB! Invalid signature</source>

--- a/client/translations/et.ts
+++ b/client/translations/et.ts
@@ -2626,4 +2626,19 @@ ID-KAARDIGA</translation>
         <translation>Vähem</translation>
     </message>
 </context>
+<context>
+    <name>QSmartCard</name>
+    <message>
+        <source>To change %1 on a PinPad reader the old %1 code has to be entered first and then the new %1 code twice.</source>
+        <translation>PinPad lugejaga %1 muutmiseks&lt;br&gt;tuleb kõigepealt sisestada vana %1 ning siis kaks korda uus %1.</translation>
+    </message>
+    <message>
+        <source>To change %1 code with the PUK code on a PinPad reader the PUK code has to be entered first and then the %1 code twice.</source>
+        <translation>PinPad lugejaga %1 muutmiseks tuleb kõigepealt&lt;br&gt;sisestada PUK ning siis kaks korda %1.</translation>
+    </message>
+    <message>
+        <source>To unblock the %1 code on a PinPad reader the PUK code has to be entered first and then the %1 code twice.</source>
+        <translation>PinPad lugejaga %1 blokeeringu tühistamiseks&lt;br&gt;tuleb kõigepealt sisestada PUK ning siis kaks korda %1.</translation>
+    </message>
+</context>
 </TS>

--- a/client/translations/ru.ts
+++ b/client/translations/ru.ts
@@ -50,7 +50,7 @@
     </message>
     <message>
         <source>Caught exception!</source>
-        <translation type="unfinished"></translation>
+        <translation>Перехвачена системная ошибка!</translation>
     </message>
     <message>
         <source>New Client window</source>
@@ -140,19 +140,19 @@
     </message>
     <message>
         <source>Failed add file to container</source>
-        <translation>Не удается добавить файл в конверт</translation>
+        <translation>Не удается добавить файл в контейнер</translation>
     </message>
     <message>
         <source>Failed remove signature from container</source>
-        <translation>Не удается удалить подпись из конверта</translation>
+        <translation>Не удается удалить подпись из контейнера</translation>
     </message>
     <message>
         <source>Failed to save container</source>
-        <translation>Не удается сохранить конверт</translation>
+        <translation>Не удается сохранить контейнер</translation>
     </message>
     <message>
         <source>Failed to sign container</source>
-        <translation>Не удается подписать конверт</translation>
+        <translation>Не удается подписать контейнер</translation>
     </message>
     <message>
         <source>You have not granted IP-based access. Check the settings of your server access certificate.</source>
@@ -171,7 +171,7 @@
     </message>
     <message>
         <source>Failed remove document from container</source>
-        <translation>Не удается удалить файл из конверта</translation>
+        <translation>Не удается удалить файл из контейнера</translation>
     </message>
     <message>
         <source>Filename: %1
@@ -243,7 +243,7 @@ Media type: %3</source>
     </message>
     <message>
         <source>This certificate cannot be used for encryption</source>
-        <translation>Данным сертификатом нельзя шифровать</translation>
+        <translation>Данным сертификатом нельзя зашифровать</translation>
     </message>
     <message>
         <source>Personal code is not valid!</source>
@@ -251,7 +251,7 @@ Media type: %3</source>
     </message>
     <message>
         <source>Person or company does not own a valid certificate.&lt;br /&gt;It is necessary to have a valid certificate for encryption.&lt;br /&gt;Contact for assistance by email &lt;a href=&quot;mailto:abi@id.ee&quot;&gt;abi@id.ee&lt;/a&gt; or call 1777 (only from Estonia), (+372) 677 3377 when calling from abroad.</source>
-        <translation>У лица или учреждения отсутствует действующий сертификат.&lt;br /&gt;Для шифрования необходим действующий сертификат.&lt;br /&gt;В случае проблем обращайтесь по адресу электронной почты &lt;a href=&quot;mailto:abi@id.ee&quot;&gt;abi@id.ee&lt;/a&gt; или звоните в пределах Эстонии на короткий номер ID-помощи 1777 или из-за границы на номер (+372) 677 3377.</translation>
+        <translation>У лица или учреждения отсутствует действующий сертификат.&lt;br /&gt;Для зашифровывания необходим действующий сертификат.&lt;br /&gt;В случае проблем обращайтесь по адресу электронной почты &lt;a href=&quot;mailto:abi@id.ee&quot;&gt;abi@id.ee&lt;/a&gt; или звоните в пределах Эстонии на короткий номер ID-помощи 1777 или из-за границы на номер (+372) 677 3377.</translation>
     </message>
 </context>
 
@@ -273,7 +273,7 @@ Media type: %3</source>
 
     <message>
         <source>Owner</source>
-        <translation>владелец</translation>
+        <translation>Владелец</translation>
     </message>
     <message>
         <source>Type</source>
@@ -319,7 +319,7 @@ Media type: %3</source>
     </message>
     <message>
         <source>Given names</source>
-        <translation>имена</translation>
+        <translation>Имена</translation>
     </message>
     <message>
         <source>Personal code</source>
@@ -348,7 +348,7 @@ Media type: %3</source>
     </message>
     <message>
         <source>Valid</source>
-        <translation>действителен</translation>
+        <translation>Действителен</translation>
     </message>
     <message>
         <source>until</source>
@@ -356,7 +356,7 @@ Media type: %3</source>
     </message>
     <message>
         <source>Expired</source>
-        <translation>недействителен</translation>
+        <translation>Недействителен</translation>
     </message>
 </context>
 
@@ -430,7 +430,7 @@ Media type: %3</source>
     </message>
     <message>
         <source>Decrypted files</source>
-        <translation>Дешифрованные файлы</translation>
+        <translation>Расшифрованные файлы</translation>
     </message>
 </context>
 
@@ -451,7 +451,7 @@ Media type: %3</source>
     </message>
     <message>
         <source>Loading data</source>
-        <translation>Читаю данные</translation>
+        <translation>Данные считываются</translation>
     </message>
 </context>
 
@@ -501,7 +501,7 @@ Learn more info here:</source>
     </message>
     <message>
         <source>Insert the card into the reader to manage the document</source>
-        <translation>Вставьте карту в считывающее устройство для управления документом</translation>
+        <translation>Вставьте карту в считывающее устройство для работы с документом</translation>
     </message>
 
     <message>
@@ -534,7 +534,7 @@ Learn more info here:</source>
     </message>
     <message>
         <source>Valid</source>
-        <translation>действительный</translation>
+        <translation>Действителен</translation>
     </message>
 
 
@@ -565,11 +565,11 @@ Learn more info here:</source>
     </message>
     <message>
         <source>No official email redirects found. To send email to @ eesti.ee, please enter your email address:</source>
-        <translation>Не найдено официальных перенаправлений электронной почты. Чтобы отправить электронное письмо на адрес @ eesti.ee, введите ваш адрес электронной почты:</translation>
+        <translation>Не найдено официальных переадресаций электронной почты. Чтобы отправить электронное письмо на адрес @ eesti.ee, введите ваш адрес электронной почты:</translation>
     </message>
     <message>
         <source>ACTIVATE REDIRECTION</source>
-        <translation>АКТИВИРОВАТЬ ПЕРЕНАПРАВЛЕНИЕ</translation>
+        <translation>АКТИВИРОВАТЬ ПЕРЕАДРЕСАЦИЮ</translation>
     </message>
     <message>
         <source>For more detailed official email address forwarding, please visit &lt;a href='http://www.eesti.ee'&gt;&lt;span style='color: #006EB5; text-decoration: none; font-weight: 900;'&gt;eesti.ee&lt;/span&gt;&lt;/a&gt;</source>
@@ -598,7 +598,7 @@ Learn more info here:</source>
     </message>
     <message>
         <source>Restrictions</source>
-        <translation>ограничения</translation>
+        <translation>Ограничения</translation>
     </message>
     <message>
         <source>Test signature</source>
@@ -675,7 +675,7 @@ Learn more info here:</source>
     </message>
     <message>
         <source>%1Forgot PIN%2?%3</source>
-        <translation>%1Забыл PIN%2?%3</translation>
+        <translation>%1Забыли PIN%2?%3</translation>
     </message>
     <message>
         <source>Signing certificate</source>
@@ -699,7 +699,7 @@ Learn more info here:</source>
     </message>
     <message>
         <source>The PUK code is located in your envelope</source>
-        <translation>Код PUK находится в конверте</translation>
+        <translation>PUK код находится в конверте</translation>
     </message>
     <message>
         <source>CHANGE PUK</source>
@@ -707,7 +707,7 @@ Learn more info here:</source>
     </message>
     <message>
         <source>%1PUK code is blocked because the PUK code has been entered 3 times incorrectly. Unable to disable the PUK code itself. %2 As long as the PUK code is blocked, all eID options can be used, except PUK code. %2You can only use the new PUK code with the new code envelope that you can use%3 from PPA%4.</source>
-        <translation>%1PUK заблокирован, потому что PUK введен неверно 3 раза. PUK невозможно разблокировать самому. %2 Пока код PUK заблокирован, можно использовать все возможности eID, кроме тех которые требуют PUK. %2 Новый PUK получите в конверте с кодами %3 из PPA%4.</translation>
+        <translation>%1PUK заблокирован, потому что PUK введен неверно 3 раза. PUK невозможно разблокировать самому. %2 Пока PUK код заблокирован, можно использовать все возможности eID, кроме тех которые требуют PUK. %2 Новый PUK получите в конверте с кодами %3 из PPA%4.</translation>
     </message>
 </context>
 
@@ -837,7 +837,7 @@ Learn more info here:</source>
     </message>
     <message>
         <source>REDIRECTION OF EESTI.EE E-MAIL</source>
-        <translation>ПЕРЕНАПРАВЛЕНИЕ EESTI.EE ПОЧТЫ</translation>
+        <translation>ПЕРЕАДРЕСАЦИЯ EESTI.EE ПОЧТЫ</translation>
     </message>
     <message>
         <source>MY OTHER eID's</source>
@@ -907,7 +907,7 @@ Learn more info here:</source>
     </message>
     <message>
         <source>Key</source>
-        <translation>ключ</translation>
+        <translation>Ключ</translation>
     </message>
     <message>
         <source>Crypto method</source>
@@ -1212,7 +1212,7 @@ Kонтрольны код: %1</translation>
     </message>
     <message>
         <source>VALID %1 CODE</source>
-        <translation>ДЕЙСТВИТЕЛЬНЫЙ %1 КОД</translation>
+        <translation>ДЕЙСТВУЮЩИЙ %1 КОД</translation>
     </message>
     <message>
         <source>CHANGE</source>
@@ -1340,7 +1340,7 @@ Kонтрольны код: %1</translation>
     </message>
     <message>
         <source>If you want to change the digital signature format then it should be done before adding signable files to the container. Otherwise the document will be created in the previous default format. When adding signatures, it is no longer possible to change the format of the document.</source>
-        <translation>Если Вы желаете изменить формат цифровой подписи, это нужно сделать до того, как Вы добавите в конверт подписываемый файл. В противном случае будет действовать формат подписи по умолчанию. Если документ уже подписан, то при добавлении к нему второй подписи формат подписи изменить невозможно.</translation>
+        <translation>Если Вы желаете изменить формат цифровой подписи, это нужно сделать до того, как Вы добавите в контейнер подписываемый файл. В противном случае будет действовать формат подписи по умолчанию. Если документ уже подписан, то при добавлении к нему второй подписи формат подписи изменить невозможно.</translation>
     </message>
     <message>
         <source>Role</source>
@@ -1797,7 +1797,7 @@ Kонтрольны код: %1</translation>
 
     <message>
         <source>Drag file here for signing</source>
-        <translation>Перетащите файл сюда для подписания или проверки ...</translation>
+        <translation>Перетащите файл сюда для подписи или проверки ...</translation>
     </message>
     <message>
         <source>Open file for signing</source>
@@ -1805,7 +1805,7 @@ Kонтрольны код: %1</translation>
     </message>
     <message>
         <source>Drag file here for encryption</source>
-        <translation>Перетащите файл сюда для шифрования или дешифрования ...</translation>
+        <translation>Перетащите файл сюда для (рас/за)шифровывания ...</translation>
     </message>
     <message>
         <source>Open file for encryption</source>
@@ -1826,11 +1826,11 @@ Kонтрольны код: %1</translation>
     </message>
     <message>
         <source>Decryption succeeded</source>
-        <translation>Расшифровка прошла успешно!</translation>
+        <translation>Расшифровывание прошло успешно!</translation>
     </message>
     <message>
         <source>Encryption succeeded</source>
-        <translation>Шифрование выполнено успешно!</translation>
+        <translation>Зашифровывание выполнено успешно!</translation>
     </message>
     <message>
         <source>Select documents</source>
@@ -1897,11 +1897,11 @@ Kонтрольны код: %1</translation>
     </message>
     <message>
         <source>Converted to signed document!</source>
-        <translation>Конвертировано в подписанный документ!</translation>
+        <translation>Переделан в контейнер для подписания!</translation>
     </message>
     <message>
         <source>Converted to crypto container!</source>
-        <translation>Konverteeritud krüptokonteineriks!</translation>
+        <translation>Переделан в контейнер для зашифровывания!</translation>
     </message>
     <message>
         <source>Move file</source>
@@ -1919,7 +1919,7 @@ Kонтрольны код: %1</translation>
 
     <message>
         <source>Card certificates need updating. Updating takes 2-10 minutes and requires a live internet connection. The card must not be removed from the reader before the end of the update.</source>
-        <translation>Карточные сертификаты нуждаются в обновлении. Обновление занимает 2-10 минут и требует подключения к Интернету в режиме реального времени. Карту нельзя удалять из считывателя до окончания обновления.</translation>
+        <translation>Сертификаты карты нуждаются в обновлении. Обновление занимает 2-10 минут и требует подключения к Интернету в режиме реального времени. Карту нельзя удалять из считывателя до окончания обновления.</translation>
     </message>
     <message>
         <source>Update</source>
@@ -1983,7 +1983,7 @@ Kонтрольны код: %1</translation>
     </message>
     <message>
         <source>You have not signed this container</source>
-        <translation>Данный контейнер не подписан вами</translation>
+        <translation>Данный контейнер вами не подписан</translation>
     </message>
     <message>
         <source>Container is unsigned</source>
@@ -2081,7 +2081,7 @@ Kонтрольны код: %1</translation>
         <source>You&apos;ve added %n file(s) to container, but these are not signed yet.
 Should I keep the unsigned container or remove it?</source>
         <translation>
-            <numerusform>В контейнер добавлено %n файл, но они не подписаны.
+            <numerusform>В контейнер добавлен %n файл, но он не подписан.
 Оставить неподписанный контейнер или стереть?</numerusform>
             <numerusform>В контейнер добавлено %n файла, но они не подписаны.
 Оставить неподписанный контейнер или стереть?</numerusform>
@@ -2122,7 +2122,7 @@ Should I keep the unsigned container or remove it?</source>
     <message>
         <source>Cannot add container to same container
 %1</source>
-        <translation>Невозможно добавить файл в один и тот же контейнер
+        <translation>Невозможно добавить контейнер в тот же контейнер
 %1</translation>
     </message>
     <message>
@@ -2149,15 +2149,15 @@ already in container, ovewrite?</source>
     </message>
     <message>
         <source>Cards</source>
-        <translation type="unfinished"></translation>
+        <translation>Карточки</translation>
     </message>
     <message>
         <source>Languages</source>
-        <translation type="unfinished"></translation>
+        <translation>Языки</translation>
     </message>
     <message>
         <source>Card info</source>
-        <translation type="unfinished"></translation>
+        <translation>Инфо карточки</translation>
     </message>
     <message>
         <source>All fields are optional</source>
@@ -2291,7 +2291,7 @@ ASiC-E – это разрабатываемый международный фо
     </message>
     <message>
         <source>Encrypting</source>
-        <translation>Шифровка</translation>
+        <translation>Зашифровывание</translation>
     </message>
 </context>
 
@@ -2443,7 +2443,7 @@ ASiC-E – это разрабатываемый международный фо
     </message>
     <message>
         <source>ISSUER OF CERTIFICATE</source>
-        <translation>ИМЯ ВЫДАВШЕГО СЕРТИФИКАТА</translation>
+        <translation>ИМЯ ВЫДАВШЕГО СЕРТИФИКАТ</translation>
     </message>
     <message>
         <source>The print out of files listed in the section &lt;b&gt;&quot;Signed Files&quot;&lt;/b&gt; are inseparable part of this Validity Confirmation Sheet.</source>
@@ -2533,7 +2533,7 @@ ASiC-E – это разрабатываемый международный фо
     </message>
     <message>
         <source>Failed to login token</source>
-        <translation type="unfinished"></translation>
+        <translation>PIN код не подтвежден</translation>
     </message>
     <message>
         <source>Failed to sign document</source>
@@ -2572,11 +2572,11 @@ ASiC-E – это разрабатываемый международный фо
     </message>
     <message>
         <source>EncryptContainer</source>
-        <translation>ШИФРОВАТЬ</translation>
+        <translation>ЗАШИФРОВАТЬ</translation>
     </message>
     <message>
         <source>DecryptContainer</source>
-        <translation>ДЕКОДИРОВАРЬ
+        <translation>РАСШИФРОВАТЬ
 С ID-КАРТОЙ</translation>
     </message>
 </context>
@@ -2607,7 +2607,7 @@ ASiC-E – это разрабатываемый международный фо
     </message>
     <message>
         <source>Invalid response</source>
-        <translation>Недействительный ответ</translation>
+        <translation>Неверный ответ</translation>
     </message>
     <message>
         <source>Loading Email info</source>
@@ -2619,7 +2619,7 @@ ASiC-E – это разрабатываемый международный фо
     </message>
     <message>
         <source>SSL context is missing</source>
-        <translation>Не удалось создать контекст SSL</translation>
+        <translation>Отсутствует контекст SSL</translation>
     </message>
 </context>
 <context>
@@ -2634,6 +2634,21 @@ ASiC-E – это разрабатываемый международный фо
     <message>
         <source>Less</source>
         <translation>Меньше</translation>
+    </message>
+</context>
+<context>
+    <name>QSmartCard</name>
+    <message>
+        <source>To change %1 on a PinPad reader the old %1 code has to be entered first and then the new %1 code twice.</source>
+        <translation>Для замены %1 кода Вам необходимо ввести один раз&lt;br&gt;действующий %1 код и два раза новый %1 код с помощью PinPad.</translation>
+    </message>
+    <message>
+        <source>To change %1 code with the PUK code on a PinPad reader the PUK code has to be entered first and then the %1 code twice.</source>
+        <translation>Для изменения %1 кода с помощью PUK кода Вам необходимо&lt;br&gt;ввести один раз PUK код и два раза новый %1 код с помощью PinPad.</translation>
+    </message>
+    <message>
+        <source>To unblock the %1 code on a PinPad reader the PUK code has to be entered first and then the %1 code twice.</source>
+        <translation>Для разблокировки %1 кода Вам необходимо ввести один раз&lt;br&gt;PUK код и два раза новый %1 код с помощью PinPad.</translation>
     </message>
 </context>
 </TS>

--- a/client/translations/ru.ts
+++ b/client/translations/ru.ts
@@ -239,7 +239,7 @@ Media type: %3</source>
     </message>
     <message>
         <source>Failed to read certificate</source>
-        <translation>Чтение сертификата неуспешно</translation>
+        <translation>Не удалось прочитать сертификат</translation>
     </message>
     <message>
         <source>This certificate cannot be used for encryption</source>
@@ -247,11 +247,11 @@ Media type: %3</source>
     </message>
     <message>
         <source>Personal code is not valid!</source>
-        <translation>Личный код некорректен!</translation>
+        <translation>Личный код недействителен!</translation>
     </message>
     <message>
         <source>Person or company does not own a valid certificate.&lt;br /&gt;It is necessary to have a valid certificate for encryption.&lt;br /&gt;Contact for assistance by email &lt;a href=&quot;mailto:abi@id.ee&quot;&gt;abi@id.ee&lt;/a&gt; or call 1777 (only from Estonia), (+372) 677 3377 when calling from abroad.</source>
-        <translation>У лица или учреждения отсутствует действительный сертификат.&lt;br /&gt;Для шифрования необходим действительный сертификат.&lt;br /&gt;В случае проблем обращайтесь по адресу электронной почты &lt;a href=&quot;mailto:abi@id.ee&quot;&gt;abi@id.ee&lt;/a&gt; или звоните в пределах Эстонии на короткий номер ID-помощи 1777 или из-за границы на номер (+372) 677 3377.</translation>
+        <translation>У лица или учреждения отсутствует действующий сертификат.&lt;br /&gt;Для шифрования необходим действующий сертификат.&lt;br /&gt;В случае проблем обращайтесь по адресу электронной почты &lt;a href=&quot;mailto:abi@id.ee&quot;&gt;abi@id.ee&lt;/a&gt; или звоните в пределах Эстонии на короткий номер ID-помощи 1777 или из-за границы на номер (+372) 677 3377.</translation>
     </message>
 </context>
 
@@ -348,7 +348,7 @@ Media type: %3</source>
     </message>
     <message>
         <source>Valid</source>
-        <translation>действительный</translation>
+        <translation>действителен</translation>
     </message>
     <message>
         <source>until</source>
@@ -356,7 +356,7 @@ Media type: %3</source>
     </message>
     <message>
         <source>Expired</source>
-        <translation>Истекший</translation>
+        <translation>недействителен</translation>
     </message>
 </context>
 
@@ -415,6 +415,10 @@ Media type: %3</source>
     <message>
         <source>Container's signatures</source>
         <translation>Подписи контейнера</translation>
+    </message>
+    <message>
+        <source>Container's timestamps</source>
+        <translation>Временные штампы контейнерa</translation>
     </message>
     <message>
         <source>Recipients</source>
@@ -1146,10 +1150,11 @@ Kонтрольны код: %1</translation>
         <source>ConditionsUnlockPIN2</source>
         <translation>&lt;ul&gt;
 &lt;li&gt;Чтобы разблокировать PIN2, введите сначала PUK код.&lt;/li&gt;
-&lt;li&gt;Вы можете найти PUK код в конверте с кодами, если вы еще не&lt;br&gt;
-поменяли его.&lt;/li&gt;
-&lt;li&gt;Если вы не знаете PUK код своей ID-карты, посетите&lt;br&gt;
-центр обслуживания, где вы сможете получить новый конверт с кодами.&lt;/li&gt;
+&lt;li&gt;Вы можете найти PUK код в конверте с кодами,&lt;br&gt;
+если вы еще не поменяли его.&lt;/li&gt;
+&lt;li&gt;Если вы не знаете PUK код своей ID-карты,&lt;br&gt;
+посетите центр обслуживания, где вы сможете получить&lt;br&gt;
+новый конверт с кодами.&lt;/li&gt;
 &lt;/ul&gt;</translation>
     </message>
     <message>
@@ -1157,10 +1162,11 @@ Kонтрольны код: %1</translation>
         <translation>
 &lt;ul&gt;
 &lt;li&gt;Чтобы разблокировать PIN1, введите сначала PUK код.&lt;/li&gt;
-&lt;li&gt;Вы можете найти PUK код в конверте с кодами, если вы еще не&lt;br&gt;
-поменяли его.&lt;/li&gt;
-&lt;li&gt;Если вы не знаете PUK код своей ID-карты, посетите&lt;br&gt;
-центр обслуживания, где вы сможете получить новый конверт с кодами.&lt;/li&gt;
+&lt;li&gt;Вы можете найти PUK код в конверте с кодами,&lt;br&gt;
+если вы еще не поменяли его.&lt;/li&gt;
+&lt;li&gt;Если вы не знаете PUK код своей ID-карты,&lt;br&gt;
+посетите центр обслуживания, где вы сможете получить&lt;br&gt;
+новый конверт с кодами.&lt;/li&gt;
 &lt;/ul&gt;</translation>
     </message>
     <message>
@@ -1168,8 +1174,9 @@ Kонтрольны код: %1</translation>
         <translation>&lt;ul&gt;
 &lt;li&gt;Новый PIN2 должен отличаться от старого.&lt;/li&gt;
 &lt;li&gt;PIN2 код используется для предоставления цифровой подписи.&lt;/li&gt;
-&lt;li&gt;Если PIN2 введён 3 раза неверно, тогда блокируется сертификат&lt;br&gt;
-цифровой подписи и использовать ID-карту для цифровой подписи невозможно,&lt;br&gt;
+&lt;li&gt;Если PIN2 введён 3 раза неверно, тогда блокируется&lt;br&gt;
+сертификат цифровой подписи и использовать ID-карту&lt;br&gt;
+для цифровой подписи невозможно,&lt;br&gt;
 пока  блокировка не снята PUK кодом.&lt;/li&gt;
 &lt;/ul&gt;</translation>
     </message>
@@ -1178,17 +1185,18 @@ Kонтрольны код: %1</translation>
         <translation>&lt;ul&gt;
 &lt;li&gt;Новый PIN1 должен отличаться от старого.&lt;/li&gt;
 &lt;li&gt;PIN1 код используется для идентификации личности.&lt;/li&gt;
-&lt;li&gt;Если PIN1 введён 3 раза неверно, тогда блокируется идентификационный&lt;br&gt;
-сертификат и использовать ID-карту невозможно, пока блокировка не снята PUK кодом.&lt;/li&gt;
+&lt;li&gt;Если PIN1 введён 3 раза неверно, тогда блокируется&lt;br&gt;
+идентификационный сертификат и использовать ID-карту невозможно,&lt;br&gt;
+пока блокировка не снята PUK кодом.&lt;/li&gt;
 &lt;/ul&gt;</translation>
     </message>
     <message>
         <source>ConditionsChangePUK</source>
         <translation>&lt;ul&gt;
-&lt;li&gt;Если PUK введён 3 раза неверно, тогда он блокируется.&lt;br&gt;
-Сертификаты можно использовать пока не будут введены 3 раза неправильные&lt;br&gt;
-PIN1 или PIN2. Тогда, для получения новых кодов своей ID-карты, посетите&lt;br&gt;
-&lt;u&gt;центр обслуживания.&lt;/u&gt;.&lt;/li&gt;
+&lt;li&gt;Если PUK введён 3 раза неверно, то он блокируется.&lt;br&gt;
+Сертификаты можно использовать пока не будут введены&lt;br&gt;
+3 раза неправильные PIN1 или PIN2. Тогда, для получения&lt;br&gt;
+новых кодов своей ID-карты, посетите &lt;u&gt;центр обслуживания.&lt;/u&gt;.&lt;/li&gt;
 &lt;li&gt;Ваш PUK код находится конверте с кодами.&lt;/li&gt;
 &lt;/ul&gt;</translation>
     </message>
@@ -1459,10 +1467,6 @@ PIN1 или PIN2. Тогда, для получения новых кодов с
     <message>
         <source>SAVE WITHOUT SIGNING</source>
         <translation>СОХРАНИТЬ БЕЗ ПОДПИСИ</translation>
-    </message>
-    <message>
-        <source>Container's timestamps</source>
-        <translation>Временные штампы контейнерa</translation>
     </message>
     <message>
         <source>NB! Invalid signature</source>

--- a/client/widgets/Accordion.cpp
+++ b/client/widgets/Accordion.cpp
@@ -113,7 +113,6 @@ void Accordion::updateInfo( const QSmartCard *smartCard )
 	ui->otherID->update("Other ID");
 
 	ui->titleOtherData->setVisible( !( t.version() == QSmartCardData::VER_USABLEUPDATER || t.authCert().subjectInfo( "O" ).contains( "E-RESIDENT" ) ) );
-//	ui->titleOtherData->setDisabled( t.version() == QSmartCardData::VER_USABLEUPDATER || t.authCert().subjectInfo( "O" ).contains( "E-RESIDENT" ) );
 }
 
 void Accordion::changeEvent(QEvent* event)
@@ -183,10 +182,10 @@ void Accordion::updateDigiIdInfo()
 	QVariant digiIdData = property("DIGI_ID_STATUS").value<QVariant>();
 
 	ui->digiID->updateDigiId(
-		"PA789456123",
-		"01.01.2022",
-		"Activ",
-		"07.08.2022, 20:59:59" );
+		"",
+		"",
+		"",
+		"" );
 
 	ui->digiID->show();
 }

--- a/client/widgets/ContainerPage.cpp
+++ b/client/widgets/ContainerPage.cpp
@@ -351,7 +351,7 @@ void ContainerPage::transition(DigiDoc* container)
 
 	if(!container->timestamps().isEmpty())
 	{
-		ui->rightPane->addHeader(tr("Container's timestamps"));
+		ui->rightPane->addHeader("Container's timestamps");
 
 		for(const DigiDocSignature &c: container->timestamps())
 			ui->rightPane->addHeaderWidget(new SignatureItem(c, state, false, ui->rightPane));

--- a/client/widgets/InfoStack.ui
+++ b/client/widgets/InfoStack.ui
@@ -76,7 +76,7 @@ border-width: 1px 0px 0px 0px;
         <x>248</x>
         <y>120</y>
         <width>300</width>
-        <height>17</height>
+        <height>19</height>
        </rect>
       </property>
       <property name="font">
@@ -144,7 +144,7 @@ border-width: 1px 0px 0px 0px;
         <x>138</x>
         <y>120</y>
         <width>100</width>
-        <height>17</height>
+        <height>19</height>
        </rect>
       </property>
       <property name="font">

--- a/client/widgets/ItemList.cpp
+++ b/client/widgets/ItemList.cpp
@@ -91,9 +91,9 @@ QString ItemList::addLabel()
 {
 	switch(itemType)
 	{
-	case ItemFile: return tr("Add more files");
-	case ItemAddress: return tr("Add addressee");
-	case ToAddAdresses: return tr("Add all");
+	case ItemFile: return "Add more files";
+	case ItemAddress: return "Add addressee";
+	case ToAddAdresses: return "Add all";
 	default: return "";
 	}
 }
@@ -203,7 +203,7 @@ void ItemList::init(ItemType item, const QString &header)
 	}
 	else
 	{
-		ui->add->init(LabelButton::DeepCeruleanWithLochmara, addLabel(), itemType == ItemFile ? FileAdd : AddressAdd);
+		ui->add->init(LabelButton::DeepCeruleanWithLochmara, tr(qPrintable(addLabel())), itemType == ItemFile ? FileAdd : AddressAdd);
 		ui->add->setFont(Styles::font(Styles::Condensed, 12));
 	}
 

--- a/client/widgets/OtherData.cpp
+++ b/client/widgets/OtherData.cpp
@@ -46,7 +46,7 @@ OtherData::OtherData(QWidget *parent)
 	ui->activate->setStyleSheet(
 			"padding: 6px 9px;"
 			"QPushButton { border-radius: 2px; border: none; color: #ffffff; background-color: #006EB5;}"
-			"QPushButton:pressed { background-color: #41B6E6;}"
+			"QPushButton:pressed { border: none; background-color: #006EB5;}"
 			"QPushButton:hover:!pressed { background-color: #008DCF;}"
 			"QPushButton:disabled { background-color: #BEDBED;};"
 			);

--- a/client/widgets/OtherData.ui
+++ b/client/widgets/OtherData.ui
@@ -61,7 +61,7 @@ color: #353739;</string>
      </property>
      <property name="styleSheet">
       <string notr="true">QPushButton { padding: 6px 9px; border-radius: 2px; border: 1px solid #006EB5; color: #006EB5; background-color: #FFFFFF;}
-QPushButton:pressed { border: 1px solid #41B6E6; color: #41B6E6;}
+QPushButton:pressed {  border: none; background-color: #006EB5; color: #FFFFFF;}
 QPushButton:hover:!pressed { border: 1px solid #008DCF; color: #008DCF;}
 QPushButton:disabled { border: 1px solid #BEDBED; color: #BEDBED;};
 </string>

--- a/client/widgets/VerifyCert.cpp
+++ b/client/widgets/VerifyCert.cpp
@@ -281,8 +281,8 @@ void VerifyCert::changePinStyle( const QString &background )
 {  
  	ui->changePIN->setStyleSheet(  
  		QString("QPushButton { border-radius: 2px; border: 1px solid #006EB5; color: #006EB5; background-color: %1;}"  
- 		"QPushButton:pressed { border: 1px solid #41B6E6; color: #41B6E6;}"  
- 		"QPushButton:hover:!pressed { border: 1px solid #008DCF; color: #008DCF;}"  
+ 		"QPushButton:pressed { border: none; background-color: #006EB5; color: %1;}"  
+ 		"QPushButton:hover:!pressed { border-radius: 2px; border: 1px solid #008DCF; color: #008DCF;}"  
  		"QPushButton:disabled { border: 1px solid #BEDBED; color: #BEDBED;};").arg( background )  
  		);  
 }

--- a/client/widgets/WarningItem.cpp
+++ b/client/widgets/WarningItem.cpp
@@ -20,14 +20,17 @@
 #include "WarningItem.h"
 #include "ui_WarningItem.h"
 
+#include "MainWindow.h"
 #include "Styles.h"
+#include "VerifyCert.h"
 
 
-WarningText::WarningText(const QString &text, const QString &details, int page)
+WarningText::WarningText(const QString &text, const QString &details, int page, const QString &property)
 : text(text)
 , details(details)
 , external(false)
 , page(page)
+, property(property)
 {}
 
 WarningText::WarningText(const QString &text, const QString &details, bool external, const QString &property)
@@ -38,11 +41,11 @@ WarningText::WarningText(const QString &text, const QString &details, bool exter
 , page(-1)
 {}
 
-
 WarningItem::WarningItem(const WarningText &warningText, QWidget *parent)
 : StyledWidget(parent)
 , ui(new Ui::WarningItem)
 , context(warningText.page)
+, warnText(warningText)
 {
 	ui->setupUi(this);
 	ui->warningText->setFont(Styles::font(Styles::Regular, 14));
@@ -71,4 +74,34 @@ bool WarningItem::appearsOnPage(int page) const
 int WarningItem::page() const
 {
 	return context;
+}
+
+void WarningItem::changeEvent(QEvent* event)
+{
+	if (event->type() == QEvent::LanguageChange)
+	{
+		ui->retranslateUi(this);
+
+		if( !warnText.property.isEmpty() )
+		{
+			if( warnText.property.toLatin1() == UNBLOCK_PIN2_WARNING )
+			{
+				warnText.text = VerifyCert::tr("PIN%1 has been blocked because PIN%1 code has been entered incorrectly 3 times. Unblock to reuse PIN%1.").arg("2");
+				warnText.details = QString("<a href='#unblock-PIN2'><span style='color:rgb(53, 55, 57)'>%1</span></a>").arg(VerifyCert::tr("UNBLOCK"));
+			}
+			else if( warnText.property.toLatin1() == UNBLOCK_PIN1_WARNING )
+			{
+				warnText.text = VerifyCert::tr("PIN%1 has been blocked because PIN%1 code has been entered incorrectly 3 times. Unblock to reuse PIN%1.").arg("1");
+				warnText.details = QString("<a href='#unblock-PIN1'><span style='color:rgb(53, 55, 57)'>%1</span></a>").arg(VerifyCert::tr("UNBLOCK"));
+			}
+			else if( warnText.property.toLatin1() == UPDATE_CERT_WARNING )
+			{
+				warnText.text = MainWindow::tr("Card certificates need updating. Updating takes 2-10 minutes and requires a live internet connection. The card must not be removed from the reader before the end of the update.");
+				warnText.details = QString("<a href='#update-Certificate'><span style='color:rgb(53, 55, 57)'>%1</span></a>").arg(tr("Update"));
+			}
+		}
+		ui->warningText->setText(warnText.text);
+		ui->warningAction->setText(warnText.details);
+	}
+	QWidget::changeEvent(event);
 }

--- a/client/widgets/WarningItem.h
+++ b/client/widgets/WarningItem.h
@@ -31,7 +31,7 @@ struct WarningText {
 	QString property;
 	int page;
 
-	WarningText(const QString &text, const QString &details = QString(), int page = -1);
+	WarningText(const QString &text, const QString &details = QString(), int page = -1, const QString &property = QString());
 	WarningText(const QString &text, const QString &details, bool external, const QString &property);
 };
 
@@ -50,7 +50,11 @@ public:
 signals:
 	void linkActivated(const QString& link);
 
+protected:
+	void changeEvent(QEvent* event) override;
+
 private:
 	Ui::WarningItem *ui;
 	int context;
+    WarningText warnText;
 };

--- a/client/widgets/WarningRibbon.cpp
+++ b/client/widgets/WarningRibbon.cpp
@@ -69,3 +69,17 @@ void WarningRibbon::setCount(int count)
 	else
 		ui->details->setText(tr("%n message", "", count));
 }
+
+void WarningRibbon::changeEvent(QEvent* event)
+{
+	if (event->type() == QEvent::LanguageChange)
+	{
+		ui->retranslateUi(this);
+
+		if(expanded)
+			ui->details->setText(tr("Less"));
+		else
+			ui->details->setText(tr("%n message", "", count));
+	}
+	QWidget::changeEvent(event);
+}

--- a/client/widgets/WarningRibbon.h
+++ b/client/widgets/WarningRibbon.h
@@ -35,6 +35,9 @@ public:
 	bool isExpanded() const;
 	void setCount(int count);
 
+protected:
+	void changeEvent(QEvent* event) override;
+
 private:
 	Ui::WarningRibbon *ui;
 	int count;


### PR DESCRIPTION
     1. EIDC-104
     2. EIDC-103 (3., 4.) Pressed button in blue color.
     3. EIDC-110. If pin is blocked the warning is shown in all pages.
        If user clicks on unblock link then goes to EID page and shows
	unblock dialog. Change of language is supported for 3 warnings
	only.
     4. Chanhe of language fixes for 'Container timestamp', '+ Add file' and other
     messages.
     5.  EIDC-101 - 'PIN1 koodi vahtamin' text fix.
     6. My Other ID-> Digi-ID example text is removed.

Signed-off-by: Oleg Prokofjev <oleg@aktors.ee>