### PR TITLE
UI styling fixes

### DIFF
--- a/client/dialogs/CertificateDetails.ui
+++ b/client/dialogs/CertificateDetails.ui
@@ -245,7 +245,18 @@ span {
             </font>
            </property>
            <property name="styleSheet">
-            <string notr="true">border: none;</string>
+            <string notr="true">#tblDetails {
+	border:none;
+}
+QHeaderView::section {
+	border: 1px solid #D9D9D8;
+	border-width: 0px 1px 1px 0px;
+	text-align: center;
+	padding: 2px 0px 3px 0px;
+	background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+                                      stop:0 #FFFFFF, stop:1 #FFFFFF);
+}
+</string>
            </property>
            <property name="editTriggers">
             <set>QAbstractItemView::NoEditTriggers</set>

--- a/client/dialogs/CertificateHistory.ui
+++ b/client/dialogs/CertificateHistory.ui
@@ -23,7 +23,16 @@
    <item>
     <widget class="QTreeWidget" name="view">
      <property name="styleSheet">
-      <string notr="true">border: none;</string>
+      <string notr="true">#view {
+	border:none;
+}
+QHeaderView::section {
+	border: 1px solid #D9D9D8;
+	border-width: 0px 1px 1px 0px;
+	padding: 2px 0px 3px 5px;
+	background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+                                      stop:0 #FFFFFF, stop:1 #FFFFFF);
+}</string>
      </property>
      <property name="editTriggers">
       <set>QAbstractItemView::CurrentChanged</set>

--- a/client/dialogs/KeyDialog.ui
+++ b/client/dialogs/KeyDialog.ui
@@ -30,7 +30,16 @@
    <item>
     <widget class="QTreeWidget" name="view">
      <property name="styleSheet">
-      <string notr="true">border: none;</string>
+      <string notr="true">#view {
+	border:none;
+}
+QHeaderView::section {
+	border: 1px solid #D9D9D8;
+	border-width: 0px 1px 1px 0px;
+	padding: 2px 0px 3px 5px;
+	background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+                                      stop:0 #FFFFFF, stop:1 #FFFFFF);
+}</string>
      </property>
      <property name="rootIsDecorated">
       <bool>false</bool>

--- a/client/dialogs/MobileDialog.ui
+++ b/client/dialogs/MobileDialog.ui
@@ -132,6 +132,9 @@ border-radius: 2px;
    <property name="echoMode">
     <enum>QLineEdit::Normal</enum>
    </property>
+   <property name="placeholderText">
+    <string>37254321</string>
+   </property>
   </widget>
   <widget class="QLabel" name="labelPhone">
    <property name="geometry">
@@ -241,6 +244,9 @@ border-radius: 2px;
    </property>
    <property name="echoMode">
     <enum>QLineEdit::Normal</enum>
+   </property>
+   <property name="placeholderText">
+    <string>47101010033</string>
    </property>
   </widget>
  </widget>

--- a/client/dialogs/SignatureDialog.cpp
+++ b/client/dialogs/SignatureDialog.cpp
@@ -115,7 +115,7 @@ SignatureDialog::SignatureDialog(const DigiDocSignature &signature, QWidget *par
 	else if(!noError)
 	{
 		d->showErrors->show();
-		d->showErrors->borderless();		
+		d->showErrors->borderless();
 	}
 
 	QString name = !c.isNull() ? c.toString( c.showCN() ? "CN serialNumber" : "GN SN serialNumber" ) : s.signedBy();

--- a/client/dialogs/SignatureDialog.ui
+++ b/client/dialogs/SignatureDialog.ui
@@ -591,7 +591,16 @@ background-color: #FFFFFF;</string>
             </font>
            </property>
            <property name="styleSheet">
-            <string notr="true">border: none;</string>
+            <string notr="true">#signatureView {
+	border:none;
+}
+QHeaderView::section {
+	border: 1px solid #D9D9D8;
+	border-width: 0px 1px 1px 0px;
+	padding: 2px 0px 3px 5px;
+	background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+                                      stop:0 #FFFFFF, stop:1 #FFFFFF);
+}</string>
            </property>
            <property name="editTriggers">
             <set>QAbstractItemView::NoEditTriggers</set>

--- a/client/translations/en.ts
+++ b/client/translations/en.ts
@@ -935,6 +935,10 @@ Learn more info here:</translation>
         <source>%1 in reader</source>
         <translation>%1 in reader</translation>
     </message>
+    <message>
+        <source>LOAD</source>
+        <translation>LOAD</translation>
+    </message>
 </context>
 
 
@@ -1323,7 +1327,7 @@ new codes.&lt;/li&gt;
     </message>
     <message>
         <source>NEW %1 CODE AGAIN</source>
-        <translation>REPEATE NEW %1 CODE</translation>
+        <translation>REPEAT NEW %1 CODE</translation>
     </message>
     <message>
         <source>PUK remaining attempts: %1</source>

--- a/client/translations/et.ts
+++ b/client/translations/et.ts
@@ -876,7 +876,7 @@ Rohkem infot leiate siit:</translation>
     </message>
     <message>
         <source>Certificate policies</source>
-        <translation></translation>
+        <translation>Sertifikaadi reeglid</translation>
     </message>
     <message>
         <source>Authority key identifier</source>

--- a/client/translations/et.ts
+++ b/client/translations/et.ts
@@ -370,7 +370,7 @@ Tüüp: %3</translation>
     </message>
     <message>
         <source>You're using Digital identity card</source>
-        <translation>Kasutate ID-kaarti</translation>
+        <translation>See on digitaalne isikutunnistus</translation>
     </message>
     <message>
         <source>Valid</source>
@@ -934,6 +934,10 @@ Rohkem infot leiate siit:</translation>
     <message>
         <source>%1 in reader</source>
         <translation>Lugejas on %1</translation>
+    </message>
+    <message>
+        <source>LOAD</source>
+        <translation>LAADI</translation>
     </message>
 </context>
 

--- a/client/translations/ru.ts
+++ b/client/translations/ru.ts
@@ -369,7 +369,7 @@ Media type: %3</source>
     </message>
     <message>
         <source>You're using Digital identity card</source>
-        <translation>Вы используете ID-карту</translation>
+        <translation>Вы используете дигитальное удостоверение личности</translation>
     </message>
     <message>
         <source>Valid</source>
@@ -924,6 +924,11 @@ Learn more info here:</source>
     <message>
         <source>%1 in reader</source>
         <translation>В считывателе %1</translation>
+    </message>
+    <message>
+        <source>LOAD</source>
+        <translation>ЗАГРУ
+ЗИТЬ</translation>
     </message>
 </context>
 

--- a/client/widgets/CardWidget.cpp
+++ b/client/widgets/CardWidget.cpp
@@ -40,12 +40,19 @@ CardWidget::CardWidget( const QString &cardId, QWidget *parent )
 	ui->cardCode->setFont( font );
 	ui->cardStatus->setFont( font );
 	ui->cardPhoto->init( LabelButton::None, "", CardPhoto );
+	ui->load->setFont(Styles::font(Styles::Condensed, 9));
+	ui->load->hide();
 
 	cardIcon.reset( new QSvgWidget( ":/images/icon_IDkaart_green.svg", this ) );
 	cardIcon->resize( 17, 12 );
 	cardIcon->move( 164, 42 );
 
-	connect( ui->cardPhoto, &LabelButton::clicked, this, [this]() { emit photoClicked( ui->cardPhoto->pixmap() ); } );
+	connect(ui->cardPhoto, &LabelButton::clicked, this, [this]() { emit photoClicked(ui->cardPhoto->pixmap()); });
+	connect(ui->cardPhoto, &LabelButton::entered, this, [this]() { 
+		if(!ui->cardPhoto->property("PICTURE").isValid())
+			ui->load->show(); 
+		});
+	connect(ui->cardPhoto, &LabelButton::left, this, [this]() { ui->load->hide(); });
 }
 
 CardWidget::~CardWidget()
@@ -90,6 +97,7 @@ void CardWidget::update(const QSharedPointer<const QCardInfo> &ci)
 	cardInfo = ci;
 	ui->cardName->setText(cardInfo->fullName);
 	ui->cardCode->setText(cardInfo->id + "   |");
+	ui->load->setText(tr("LOAD"));
 	if(cardInfo->loading)
 	{
 		ui->cardStatus->setText(QString());

--- a/client/widgets/CardWidget.ui
+++ b/client/widgets/CardWidget.ui
@@ -140,6 +140,30 @@ border-radius: 3px;
    <property name="alignment">
     <set>Qt::AlignCenter</set>
    </property>
+   <widget class="QLabel" name="load">
+    <property name="geometry">
+     <rect>
+      <x>2</x>
+      <y>8</y>
+      <width>30</width>
+      <height>32</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>9</pointsize>
+     </font>
+    </property>
+    <property name="styleSheet">
+     <string notr="true">border: none; color: #006EB5;</string>
+    </property>
+    <property name="text">
+     <string>LOAD</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+   </widget>
   </widget>
  </widget>
  <customwidgets>

--- a/client/widgets/ContainerPage.ui
+++ b/client/widgets/ContainerPage.ui
@@ -68,14 +68,17 @@ background-color: #F4F5F6;
 </string>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout_4">
+      <property name="spacing">
+       <number>0</number>
+      </property>
       <property name="leftMargin">
-       <number>1</number>
+       <number>0</number>
       </property>
       <property name="topMargin">
        <number>3</number>
       </property>
       <property name="rightMargin">
-       <number>1</number>
+       <number>0</number>
       </property>
       <property name="bottomMargin">
        <number>7</number>
@@ -90,7 +93,7 @@ background-color: #F4F5F6;
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>6</width>
+          <width>8</width>
           <height>20</height>
          </size>
         </property>
@@ -112,7 +115,7 @@ background-color: #F4F5F6;
         </property>
         <property name="maximumSize">
          <size>
-          <width>70</width>
+          <width>74</width>
           <height>16777215</height>
          </size>
         </property>
@@ -163,6 +166,9 @@ border: none;</string>
         </property>
         <property name="text">
          <string>C:\Downloads\Leping.bdoc</string>
+        </property>
+        <property name="margin">
+         <number>5</number>
         </property>
        </widget>
       </item>
@@ -599,15 +605,15 @@ border: none;</string>
  </widget>
  <customwidgets>
   <customwidget>
+   <class>LabelButton</class>
+   <extends>QLabel</extends>
+   <header>widgets/LabelButton.h</header>
+  </customwidget>
+  <customwidget>
    <class>ItemList</class>
    <extends>QWidget</extends>
    <header>widgets/ItemList.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>LabelButton</class>
-   <extends>QLabel</extends>
-   <header>widgets/LabelButton.h</header>
   </customwidget>
   <customwidget>
    <class>FileList</class>

--- a/client/widgets/LabelButton.cpp
+++ b/client/widgets/LabelButton.cpp
@@ -86,11 +86,13 @@ void LabelButton::init( Style style, const QString &label, int code )
 void LabelButton::enterEvent( QEvent *ev )
 {
 	hover();
+	emit entered();
 }
 
 void LabelButton::leaveEvent( QEvent *ev )
 {
 	normal();
+	emit left();
 }
 
 void LabelButton::normal()

--- a/client/widgets/LabelButton.h
+++ b/client/widgets/LabelButton.h
@@ -47,6 +47,8 @@ public:
 
 signals:
 	void clicked(int code);
+	void entered();
+	void left();
 
 protected:
 	void enterEvent( QEvent *ev ) override;


### PR DESCRIPTION
- DDKLIEN-15: Placeholder texts for Mobile Dlg phone & ID code
- DDKLIEN-17: Style of table and tree widget headers (white background)
- DDKLIENT-3: Show text "LOAD" while hovering over card widget picture
- DDKLIENT-13: Smaller gap between "Container:" title and filename
- DDKLIENT-20: Correct translations of "You're.. Digital identity card"

Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>