### PR TITLE
Fix for some errors DDKLIEN-23-25

### DIFF
--- a/client/dialogs/AddRecipients.cpp
+++ b/client/dialogs/AddRecipients.cpp
@@ -75,6 +75,7 @@ void AddRecipients::init()
 	ui->cancel->setFont(Styles::font(Styles::Condensed, 14));
 	ui->confirm->setFont(Styles::font(Styles::Condensed, 14));
 
+	ui->confirm->setDisabled(!rightList.size());
 	connect(ui->confirm, &QPushButton::clicked, this, &AddRecipients::accept);
 	connect(ui->cancel, &QPushButton::clicked, this, &AddRecipients::reject);
 	connect(ui->leftPane, &ItemList::search, this, &AddRecipients::search);
@@ -168,6 +169,7 @@ void AddRecipients::addRecipientToRightPane(Item *toAdd)
 	connect(rightItem, &AddressItem::remove, this, &AddRecipients::removeRecipientFromRightPane );
 	leftItem->disable(true);
 	leftItem->showButton(AddressItem::Added);
+	ui->confirm->setDisabled(!rightList.size());
 }
 
 void AddRecipients::addAllRecipientToRightPane()
@@ -179,6 +181,7 @@ void AddRecipients::addAllRecipientToRightPane()
 			addRecipientToRightPane(it.value());
 		}
 	}
+	ui->confirm->setDisabled(!rightList.size());
 }
 
 void AddRecipients::removeRecipientFromRightPane(Item *toRemove)
@@ -193,6 +196,7 @@ void AddRecipients::removeRecipientFromRightPane(Item *toRemove)
 		it.value()->showButton(AddressItem::Add);
 		rightList.removeAll(friendlyName);
 	}
+	ui->confirm->setDisabled(!rightList.size());
 }
 
 void AddRecipients::addRecipientToLeftPane(const QSslCertificate& cert)
@@ -340,6 +344,9 @@ int AddRecipients::exec()
 
 void AddRecipients::search(const QString &term)
 {
+	QApplication::setOverrideCursor(Qt::WaitCursor);
+	ui->confirm->setDefault(false);
+	ui->confirm->setAutoDefault(false);
 	QRegExp isDigit( "\\d*" );
 
 	if( isDigit.exactMatch(term) && ( term.size() == 11 || term.size() == 8 ) )
@@ -359,6 +366,7 @@ void AddRecipients::search(const QString &term)
 
 void AddRecipients::showError( const QString &msg, const QString &details )
 {
+	QApplication::restoreOverrideCursor();
 	// disableSearch(false);
 	WarningDialog b(msg, details, this);
 	b.exec();
@@ -396,4 +404,5 @@ void AddRecipients::showResult(const QList<QSslCertificate> &result)
 			addRecipientToLeftPane(k);
 		}
 	}
+	QApplication::restoreOverrideCursor();
 }

--- a/client/dialogs/FirstRun.ui
+++ b/client/dialogs/FirstRun.ui
@@ -572,7 +572,7 @@ color: #041E42;</string>
        <x>30</x>
        <y>340</y>
        <width>298</width>
-       <height>64</height>
+       <height>70</height>
       </rect>
      </property>
      <property name="font">
@@ -602,7 +602,7 @@ line-height: 16px;</string>
        <x>363</x>
        <y>340</y>
        <width>298</width>
-       <height>64</height>
+       <height>70</height>
       </rect>
      </property>
      <property name="font">

--- a/client/dialogs/SettingsDialog.ui
+++ b/client/dialogs/SettingsDialog.ui
@@ -1782,10 +1782,15 @@ QScrollBar::handle:vertical{
 	border-radius: 2px;
 	height: 145px;
 }
-QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {
-	border: none;
-	background: #FFFFFF;
- }</string>
+QScrollBar::add-line:vertical {
+      border: none;
+      background: none;
+}
+QScrollBar::sub-line:vertical {
+      border: none;
+      background: none;
+}
+</string>
           </property>
           <property name="readOnly">
            <bool>true</bool>

--- a/client/translations/et.ts
+++ b/client/translations/et.ts
@@ -991,11 +991,11 @@ Rohkem infot leiate siit:</translation>
     </message>
     <message>
         <source>DigiDoc Client can be used to sign digitally with ID-card and Mobile-ID, check the validity of digital signatures and open and save documents inside the signature container.</source>
-        <translation>DigiDoc kliendiga saad dokumentidele anda ID-kaardi ja Mobiil-ID digitaalallkirju, kontrollida allkirjade kehtivust ning avada ja salvestada konteineris sisalduvaid dokumente.</translation>
+        <translation>DigiDoc rakendusega saad dokumentidele anda ID-kaardi ja Mobiil-ID digitaalallkirju, kontrollida allkirjade kehtivust ning avada ja salvestada konteineris sisalduvaid dokumente.</translation>
     </message>
     <message>
         <source>DigiDoc Client can also be used to encrypt data and decrypt the previously encrypted data. For encryption the program uses the authentication certificate of the ID-card.</source>
-        <translation>DigiDoc kliendiga saad ka andmeid salastada (krüpteerida) ja salastatud andmeid muuta uuesti kõigile loetavaks. Krüpteerimiseks kasutatakse ID-kaardi isikutuvastamise sertifikaati.</translation>
+        <translation>DigiDoc rakendusega saad ka andmeid salastada (krüpteerida) ja salastatud andmeid muuta uuesti kõigile loetavaks. Saad saata konfidentsiaalseid dokumente (soovitud inimesele).</translation>
     </message>
     <message>
         <source>Manage your ID-card’s PIN/PUK codes and handle certificate renewals. View and manage your other electronic identities.</source>
@@ -1023,11 +1023,11 @@ Rohkem infot leiate siit:</translation>
     </message>
     <message>
         <source>Once the files have been selected, check them and choose whether you want to sign with ID-card or Mobile-ID. You can also save the container without signing.</source>
-        <translation>Kui failid on valitud, siis kontrolli need üle ning vali, kas soovid salvestada ID-kaardi või Mobiil-ID-ga. Võid salvestada konterineri ka allkirjasta-mata.</translation>
+        <translation>Kui failid on valitud, siis kontrolli need üle ning vali, kas soovid salvestada ID-kaardi või Mobiil-ID-ga. Võid salvestada konterineri ka allkirjasta&#173;mata.</translation>
     </message>
     <message>
         <source>By entering the PIN2 code, you will have signed the document with digital signature that by law is equal to the signature signed by hand. You will find the PIN2 code in the envelope that came with your ID-card or Mobile-ID.</source>
-        <translation>Sisestades PIN2 koodi annad digitaalse allkirja, mis on seaduse ees võrdne omakäelise allkirja-ga. PIN2 koodi leiad koodiümbrikust, mille said koos ID-kaardi või Mobiili-ID-ga.</translation>
+        <translation>Sisestades PIN2 koodi annad digitaalse allkirja, mis on seaduse ees võrdne omakäelise allkirja&#173;ga. PIN2 koodi leiad koodiümbrikust, mille said koos ID-kaardi või Mobiili-ID-ga.</translation>
     </message>
     <message>
         <source>How to encrypt documents?</source>
@@ -1043,15 +1043,15 @@ Rohkem infot leiate siit:</translation>
     </message>
     <message>
         <source>A recipient must be selected in order to encrypt data. Drag the file to be encrypted from your computer to the DigiDoc application or select a file from the disk. You can drag or select multiple files at a time.</source>
-        <translation>Krüpteerimiseks peab olema valitud adressaat. Lohista krüpteeritav fail oma arvutist DigiDoc rakendusse või vali fail kettalt. Võid lohistada või valida ka mitu faili korraga.</translation>
+        <translation>Lohista krüpteeritav fail oma arvutist DigiDoc rakendusse või vali fail kettalt. Võid lohistada või valida ka mitu faili korraga.</translation>
     </message>
     <message>
         <source>Select people who can open the container. You have already been added to the address list by default so that you can also open your encrypted container.</source>
-        <translation>Vali inimesed, kes saavad faili avada. Adressaa-tide listi oled Sina juba lisatud, et saaksid ka ise oma krüpteeritud faili avada.</translation>
+        <translation>Vali inimesed, kes saavad faili avada. Adressaa&#173;tide listi oled Sina juba lisatud, et saaksid ka ise oma krüpteeritud faili avada.</translation>
     </message>
     <message>
         <source>Click the "Encrypt" button and the file is now encrypted. You now have the option to open the location of the container or forward the file by e-mail.</source>
-        <translation>Vajuta nupul “Krüpteeri” ning fail ongi krüpteeri-tud. Sul on nüüd võimalik avada konterineri asu-koht või edastada fail e-postiga.</translation>
+        <translation>Vajuta nupul “Krüpteeri” ning fail ongi krüpteeri&#173;tud. Sul on nüüd võimalik avada krüpteeritud faili või edastada fail e-postiga.</translation>
     </message>
     <message>
         <source>How to manage your electronic identities?</source>
@@ -1071,7 +1071,7 @@ Rohkem infot leiate siit:</translation>
     </message>
     <message>
         <source>Under "My eID", you will find the option to modify your PIN1, PIN2 and PUK, and the details of the certificates. Here you can also unlock the PUK code of your blocked PIN.</source>
-        <translation>“Minu eID” alt leiad oma PIN1, PIN2 ja PUK koodi muutmise võimaluse ning sertifikaatide detail-andmed. Siin saad ka oma blokeeritud PIN-e PUK koodi abil lukust lahti teha.</translation>
+        <translation>“Minu eID” alt leiad oma PIN1, PIN2 ja PUK koodi muutmise võimaluse ning sertifikaatide detail&#173;andmed. Siin saad ka oma blokeeritud PIN-e PUK koodi abil lukust lahti teha.</translation>
     </message>
     <message>
         <source>To view information about Mobile-ID and Digi-ID, you must first enter the PIN1 code. The page shows details about the validity of these certificates.</source>

--- a/client/translations/et.ts
+++ b/client/translations/et.ts
@@ -995,7 +995,7 @@ Rohkem infot leiate siit:</translation>
     </message>
     <message>
         <source>DigiDoc Client can also be used to encrypt data and decrypt the previously encrypted data. For encryption the program uses the authentication certificate of the ID-card.</source>
-        <translation>DigiDoc rakendusega saad ka andmeid salastada (krüpteerida) ja salastatud andmeid muuta uuesti kõigile loetavaks. Saad saata konfidentsiaalseid dokumente (soovitud inimesele).</translation>
+        <translation>DigiDoc rakendusega saad ka andmeid salasta&#173;da ja krüpteeritud andmeid muuta uuesti kõigile loetavaks. Salastatud konfidentsiaalseid doku&#173;mente saavad lugeda ainult soovitud inimesed.</translation>
     </message>
     <message>
         <source>Manage your ID-card’s PIN/PUK codes and handle certificate renewals. View and manage your other electronic identities.</source>
@@ -1051,7 +1051,7 @@ Rohkem infot leiate siit:</translation>
     </message>
     <message>
         <source>Click the "Encrypt" button and the file is now encrypted. You now have the option to open the location of the container or forward the file by e-mail.</source>
-        <translation>Vajuta nupul “Krüpteeri” ning fail ongi krüpteeri&#173;tud. Sul on nüüd võimalik avada krüpteeritud faili või edastada fail e-postiga.</translation>
+        <translation>Vajuta nupul “Krüpteeri” ning fail ongi krüpteeri&#173;tud. Sul on nüüd võimalik avada krüpteeritud faili asu&#173;koht või edastada fail e-postiga.</translation>
     </message>
     <message>
         <source>How to manage your electronic identities?</source>

--- a/client/translations/ru.ts
+++ b/client/translations/ru.ts
@@ -982,7 +982,7 @@ Learn more info here:</source>
     </message>
     <message>
         <source>DigiDoc Client can be used to sign digitally with ID-card and Mobile-ID, check the validity of digital signatures and open and save documents inside the signature container.</source>
-        <translation>DigiDoc приложение используется для цифро- вой подписи с помощью ID-карты и Мobiil-ID, проверки подлинности цифровых подписей, открытия и сохранения документов.</translation>
+        <translation>DigiDoc приложение используется для цифро&#173;вой подписи с помощью ID-карты и Мobiil-ID, проверки подлинности цифровых подписей, открытия и сохранения документов.</translation>
     </message>
     <message>
         <source>DigiDoc Client can also be used to encrypt data and decrypt the previously encrypted data. For encryption the program uses the authentication certificate of the ID-card.</source>
@@ -1010,7 +1010,7 @@ Learn more info here:</source>
     </message>
     <message>
         <source>To sign the file, drag it from your computer to the DigiDoc application or click the "... or load a file from disk" button. You can drag or select multiple files at a time.</source>
-        <translation>Чтобы подписать файл, перетащите его из компьютера в приложение DigiDoc или нажмите кнопку «... или загрузите файл с диска». Вы можете одновременно пере- таскивать или выбирать несколько файлов.</translation>
+        <translation>Чтобы подписать файл, перетащите его из компьютера в приложение DigiDoc или нажмите кнопку «... или загрузите файл с диска». Вы можете одновременно пере&#173;таскивать или выбирать несколько файлов.</translation>
     </message>
     <message>
         <source>Once the files have been selected, check them and choose whether you want to sign with ID-card or Mobile-ID. You can also save the container without signing.</source>
@@ -1034,7 +1034,7 @@ Learn more info here:</source>
     </message>
     <message>
         <source>A recipient must be selected in order to encrypt data. Drag the file to be encrypted from your computer to the DigiDoc application or select a file from the disk. You can drag or select multiple files at a time.</source>
-        <translation>Для шифрования данных выберите получателя. Перетащите файл, который нужно зашифро- вать, с вашего компьютера в приложение DigiDoc или выберите файл с диска. Одновре- менно можно выбирать несколько файлов.</translation>
+        <translation>Для шифрования данных выберите получателя. Перетащите файл, который нужно зашифро&#173;вать, с вашего компьютера в приложение DigiDoc или выберите файл с диска. Одновре&#173;менно можно выбирать несколько файлов.</translation>
     </message>
     <message>
         <source>Select people who can open the container. You have already been added to the address list by default so that you can also open your encrypted container.</source>
@@ -2010,7 +2010,7 @@ PUK кодом.&lt;/li&gt;
     </message>
     <message>
         <source>Added</source>
-        <translation>Добавленный</translation>
+        <translation>Добавлен</translation>
     </message>
 
     <message>

--- a/client/widgets/ItemList.cpp
+++ b/client/widgets/ItemList.cpp
@@ -211,10 +211,13 @@ void ItemList::init(ItemType item, const QString &header)
 		ui->txtFind->setFont(Styles::font(Styles::Regular, 12));
 		ui->findGroup->show();
 		ui->txtFind->setPlaceholderText(tr("Enter personal code, company or registry code"));
+		connect(ui->txtFind, &QLineEdit::returnPressed, [this](){ emit search(ui->txtFind->text()); });
 		connect(ui->btnFind, &QPushButton::clicked, [this](){ emit search(ui->txtFind->text()); });
 		ui->btnFind->setDisabled(ui->txtFind->text().isEmpty());
 		connect(ui->txtFind, &QLineEdit::textChanged, [=](const QString &text){
 			ui->btnFind->setDisabled(text.isEmpty());
+			ui->btnFind->setDefault(text.isEmpty());
+			ui->btnFind->setAutoDefault(text.isEmpty());
 		});		
 		headerItems = 2;
 	}

--- a/client/widgets/ItemList.ui
+++ b/client/widgets/ItemList.ui
@@ -71,10 +71,15 @@ QScrollBar::handle:vertical{
 	border-radius: 2px;
 	height: 145px;
 }
-QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {
-	border: none;
-	background: #FFFFFF;
- }</string>
+QScrollBar::add-line:vertical {
+      border: none;
+      background: none;
+}
+QScrollBar::sub-line:vertical {
+      border: none;
+      background: none;
+}
+</string>
      </property>
      <property name="frameShape">
       <enum>QFrame::NoFrame</enum>


### PR DESCRIPTION
   1. Add recepients:
       Confirm button is defaul unless user enters some LDAP search texts.
       Confirm button is disabled if no recepients added.
       Enter key in text field for LDAP search activates find process.
       Waiting cursor is shown.
    2.
      fix for DDKLIEN-23-25 issues. OSX to be tested. Some long estonian
      text was cut :(
    3. DDKLIEN-21 - scrollbar should not show arrows.

Signed-off-by: Oleg Prokofjev <oleg@aktors.ee>