### PR TITLE
Fix for certificate update dialog

### DIFF
--- a/client/Styles.cpp
+++ b/client/Styles.cpp
@@ -87,10 +87,6 @@ QFont Styles::font( Styles::Font font, int size, QFont::Weight weight )
 {
 	QFont f = Styles::font( font, size );
 	f.setWeight( weight );
-#ifdef Q_OS_WIN
-	// to make the bold fonts look more nice on Windows: "avoid subpixel antialiasing on the fonts if possible"
-	f.setStyleStrategy(QFont::NoSubpixelAntialias);
-#endif
 	return f;
 }
 

--- a/client/dialogs/Updater.h
+++ b/client/dialogs/Updater.h
@@ -1,5 +1,5 @@
 /*
- * QEstEidUtil
+ * QDigiDoc4
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -32,6 +32,7 @@ public:
 	~Updater();
 	int exec() override;
 	int execute();
+	void reject() override;
 
 Q_SIGNALS:
 	void log(const QString &msg);

--- a/client/dialogs/Updater.ui
+++ b/client/dialogs/Updater.ui
@@ -173,13 +173,13 @@ font-weight: 700;
          <property name="minimumSize">
           <size>
            <width>400</width>
-           <height>189</height>
+           <height>195</height>
           </size>
          </property>
          <property name="maximumSize">
           <size>
            <width>400</width>
-           <height>189</height>
+           <height>195</height>
           </size>
          </property>
          <property name="wordWrap">
@@ -211,7 +211,7 @@ font-weight: 700;
           </size>
          </property>
          <property name="layoutDirection">
-          <enum>Qt::RightToLeft</enum>
+          <enum>Qt::LeftToRight</enum>
          </property>
          <property name="styleSheet">
           <string notr="true"/>

--- a/client/translations/en.ts
+++ b/client/translations/en.ts
@@ -2069,7 +2069,12 @@ new codes.&lt;/li&gt;
         <source>Updating certificates has failed. The server is overloaded, try again later.</source>
         <translation>Updating certificates has failed. The server is overloaded, try again later.</translation>
     </message>
+    <message>
+        <source>Failed to read certificate</source>
+        <translation>Failed to read certificate</translation>
+    </message>
 </context>
+
 
 <context>
     <name>WaitDialog</name>

--- a/client/translations/et.ts
+++ b/client/translations/et.ts
@@ -1997,6 +1997,7 @@ saada on pöörduda &lt;u&gt;klienditeeninduspunkti&lt;/u&gt; poole.&lt;/li&gt;
 
 <context>
     <name>Updater</name>
+
     <message>
         <source>CLOSE</source>
         <translation>SULGE</translation>
@@ -2019,7 +2020,7 @@ saada on pöörduda &lt;u&gt;klienditeeninduspunkti&lt;/u&gt; poole.&lt;/li&gt;
     </message>
     <message>
         <source>Update in progress. The process may take up to 10 minutes. Do not remove the card from reader!</source>
-        <translation>Värskendamine toimub Protsess võib kesta kuni 10 minutit. Ärge eemaldage kaarti lugeja poolt!</translation>
+        <translation>Toimub uuendamine. Uuendamise protsess kestab kuni 10 minutit. Ära eemalda kaarti lugejast!</translation>
     </message>
     <message>
         <source>Certificate renewal</source>
@@ -2027,11 +2028,11 @@ saada on pöörduda &lt;u&gt;klienditeeninduspunkti&lt;/u&gt; poole.&lt;/li&gt;
     </message>
     <message>
         <source>I agree to the terms of use of certificates.</source>
-        <translation>I agree to the terms of use of certificates.</translation>
+        <translation>Nõustun sertifikaatide kasutustingimustega.</translation>
     </message>
     <message>
         <source>I confirm I have saved new PIN1, PIN2 and PUK code.</source>
-        <translation>I confirm I have saved a new PIN1, PIN2 and PUK code.</translation>
+        <translation>Kinnitan, et olen uued PIN- ja PUK-koodid üles kirjutanud.</translation>
     </message>
     <message>
         <source>Enter PIN</source>
@@ -2048,15 +2049,19 @@ saada on pöörduda &lt;u&gt;klienditeeninduspunkti&lt;/u&gt; poole.&lt;/li&gt;
     </message>
     <message>
         <source>Updating certificates has failed. Check your internet connection and try again.</source>
-        <translation>Sertide uuendamine on ebaõnnestunud. Kontrollige oma Interneti-ühendust ja proovige uuesti.</translation>
+        <translation>Uuendamine ebaõnnestus. Kontrolli arvuti internetiühendust ja proovi uuesti.</translation>
     </message>
     <message>
         <source>SSL handshake failed. Please restart the update process.</source>
-        <translation>SSL ühenduskanali loomine ebaõnnestus. Taaskäivitage värskendusprotsess uuesti.</translation>
+        <translation>SSL-turvakanali loomine ebaõnnestus. Palun alustage uuendamist uuesti.</translation>
     </message>
     <message>
         <source>Updating certificates has failed. The server is overloaded, try again later.</source>
-        <translation>Sertide uuendamine on ebaõnnestunud. Server on ülekoormatud, proovige hiljem uuesti.</translation>
+        <translation>Sertifikaatide uuendamine ebaõnnestus. Server on ülekoormatud, proovi mõne aja pärast uuesti.</translation>
+    </message>
+    <message>
+        <source>Failed to read certificate</source>
+        <translation>Sertifikaadi laadimine ebaõnnestus</translation>
     </message>
 </context>
 

--- a/client/translations/ru.ts
+++ b/client/translations/ru.ts
@@ -1981,7 +1981,7 @@ PUK кодом.&lt;/li&gt;
 
     <message>
         <source>CLOSE</source>
-        <translation>ЗАКРЫТЬ></translation>
+        <translation>ЗАКРЫТЬ</translation>
     </message>
     <message>
         <source>START</source>
@@ -1993,7 +1993,7 @@ PUK кодом.&lt;/li&gt;
     </message>
     <message>
         <source>DETAILS</source>
-        <translation>ДЕТАЛИ</translation>
+        <translation>ПОДРОБНОСТИ</translation>
     </message>
     <message>
         <source>CONTINUE</source>
@@ -2005,7 +2005,7 @@ PUK кодом.&lt;/li&gt;
     </message>
     <message>
         <source>Certificate renewal</source>
-        <translation>Обновление сертификата</translation>
+        <translation>Обновление сертификатов</translation>
     </message>
     <message>
         <source>I agree to the terms of use of certificates.</source>
@@ -2013,7 +2013,7 @@ PUK кодом.&lt;/li&gt;
     </message>
     <message>
         <source>I confirm I have saved new PIN1, PIN2 and PUK code.</source>
-        <translation>Я подтверждаю, что сохранил новые PIN1, PIN2 и PUK коды.</translation>
+        <translation>Подтверждаю что записал новые значения для PIN- и PUK-кодов.</translation>
     </message>
     <message>
         <source>Enter PIN</source>
@@ -2030,15 +2030,19 @@ PUK кодом.&lt;/li&gt;
     </message>
     <message>
         <source>Updating certificates has failed. Check your internet connection and try again.</source>
-        <translation>Ошибка обновления сертификатов. Проверьте подключение к Интернету и повторите попытку.</translation>
+        <translation>Не удалось обновить сертификаты. Проверьте подключение к Интернету и повторите попытку.</translation>
     </message>
     <message>
         <source>SSL handshake failed. Please restart the update process.</source>
-        <translation>Не удалось создать SSL канал передачи данных. Пожалуйста, перезапустите процесс обновления.</translation>
+        <translation>Создание защищённого SSL канала не удалось. Просьба начать процесс обновления сначала.</translation>
     </message>
     <message>
         <source>Updating certificates has failed. The server is overloaded, try again later.</source>
-        <translation>Ошибка обновления сертификатов. Сервер перегружен, повторите попытку позже.</translation>
+        <translation>Не удалось обновить сертификаты. Сервер перегружен, попробуйте обновить сертификаты позже.</translation>
+    </message>
+    <message>
+        <source>Failed to read certificate</source>
+        <translation>Не удалось прочитать сертификат</translation>
     </message>
 </context>
 


### PR DESCRIPTION
    1. DDKLIEN-40 ticket:
         - fixed the logic as in the latest qesteidutil
         - fixed the texts to be as in qesteidutil
	 - ESC key is disabled, as application hangs as qesteidutil
    2. DDKLIEN-30 ticket:
         - checkbox to correct side
	 - increased the label text area
    3. Windows fonts to look better.

Signed-off-by: Oleg Prokofjev oleg@aktors.ee