### PR TITLE
Address item translation

### DIFF
--- a/client/dialogs/FirstRun.ui
+++ b/client/dialogs/FirstRun.ui
@@ -26,7 +26,7 @@
     </rect>
    </property>
    <property name="currentIndex">
-    <number>1</number>
+    <number>0</number>
    </property>
    <widget class="QWidget" name="langPage">
     <property name="styleSheet">

--- a/client/dialogs/FirstRun.ui
+++ b/client/dialogs/FirstRun.ui
@@ -26,7 +26,7 @@
     </rect>
    </property>
    <property name="currentIndex">
-    <number>0</number>
+    <number>1</number>
    </property>
    <widget class="QWidget" name="langPage">
     <property name="styleSheet">
@@ -572,7 +572,7 @@ color: #041E42;</string>
        <x>30</x>
        <y>340</y>
        <width>298</width>
-       <height>70</height>
+       <height>72</height>
       </rect>
      </property>
      <property name="font">
@@ -602,7 +602,7 @@ line-height: 16px;</string>
        <x>363</x>
        <y>340</y>
        <width>298</width>
-       <height>70</height>
+       <height>72</height>
       </rect>
      </property>
      <property name="font">
@@ -632,7 +632,7 @@ line-height: 16px;</string>
        <x>696</x>
        <y>340</y>
        <width>298</width>
-       <height>64</height>
+       <height>72</height>
       </rect>
      </property>
      <property name="font">
@@ -1112,7 +1112,7 @@ color: #041E42;</string>
        <x>30</x>
        <y>386</y>
        <width>298</width>
-       <height>86</height>
+       <height>88</height>
       </rect>
      </property>
      <property name="font">
@@ -1142,7 +1142,7 @@ line-height: 16px;</string>
        <x>363</x>
        <y>386</y>
        <width>298</width>
-       <height>80</height>
+       <height>88</height>
       </rect>
      </property>
      <property name="font">
@@ -1195,7 +1195,7 @@ color: #041E42;</string>
        <x>696</x>
        <y>386</y>
        <width>298</width>
-       <height>85</height>
+       <height>88</height>
       </rect>
      </property>
      <property name="font">
@@ -1411,7 +1411,7 @@ color: #041E42;</string>
        <x>30</x>
        <y>386</y>
        <width>298</width>
-       <height>85</height>
+       <height>88</height>
       </rect>
      </property>
      <property name="font">
@@ -1441,7 +1441,7 @@ line-height: 16px;</string>
        <x>363</x>
        <y>386</y>
        <width>298</width>
-       <height>80</height>
+       <height>88</height>
       </rect>
      </property>
      <property name="font">
@@ -1494,7 +1494,7 @@ color: #041E42;</string>
        <x>696</x>
        <y>386</y>
        <width>298</width>
-       <height>80</height>
+       <height>88</height>
       </rect>
      </property>
      <property name="font">
@@ -1863,7 +1863,7 @@ color: #041E42;</string>
        <x>30</x>
        <y>386</y>
        <width>298</width>
-       <height>64</height>
+       <height>88</height>
       </rect>
      </property>
      <property name="font">
@@ -1893,7 +1893,7 @@ line-height: 16px;</string>
        <x>363</x>
        <y>386</y>
        <width>298</width>
-       <height>64</height>
+       <height>88</height>
       </rect>
      </property>
      <property name="font">
@@ -1923,7 +1923,7 @@ line-height: 16px;</string>
        <x>696</x>
        <y>386</y>
        <width>298</width>
-       <height>85</height>
+       <height>88</height>
       </rect>
      </property>
      <property name="font">

--- a/client/dialogs/KeyDialog.ui
+++ b/client/dialogs/KeyDialog.ui
@@ -23,7 +23,9 @@
    <string>Encrypt for</string>
   </property>
   <property name="styleSheet">
-   <string notr="true">QWidget#KeyDialog{ border-radius: 2px; background-color: #FFFFFF; border: none;}</string>
+   <string notr="true">QWidget{ background-color: #FFFFFF; border: none;}
+QWidget#KeyDialog{ border-radius: 2px; }
+</string>
   </property>
   <layout class="QVBoxLayout" name="KeyDialogLayout">
    <item>

--- a/client/dialogs/WarningDialog.cpp
+++ b/client/dialogs/WarningDialog.cpp
@@ -59,7 +59,9 @@ WarningDialog::WarningDialog(const QString &text, const QString &details, QWidge
 		connect(ui->showDetails, &AccordionTitle::opened, this, &WarningDialog::adjustSize);
 	}
 	adjustSize();
+#ifndef Q_OS_MAC
 	setFixedSize( size() );
+#endif
 }
 
 WarningDialog::WarningDialog(const QString &text, QWidget *parent)
@@ -113,7 +115,9 @@ void WarningDialog::setText(const QString& text)
 {
 	ui->text->setText(text);
 	adjustSize();
+#ifndef Q_OS_MAC
 	setFixedSize( size() );
+#endif
 }
 
 void WarningDialog::warning(QWidget *parent, const QString& text)

--- a/client/translations/ru.ts
+++ b/client/translations/ru.ts
@@ -17,7 +17,7 @@
     </message>
     <message>
         <source>Failed to save server access certificate file to KeyChain!</source>
-        <translation type="unfinished"></translation>
+        <translation>Не удалось сохранить файл сертификата доступа к серверу в цепочку ключей!</translation>
     </message>
     <message>
         <source>Server access certificate expired on %1. To renew the certificate please contact IT support team of your company. Additional information is available &lt;a href=&quot;mailto:sales@sk.ee&quot;&gt;sales@sk.ee&lt;/a&gt; or phone (+372) 610 1892</source>
@@ -404,7 +404,7 @@ Media type: %3</source>
     </message>
     <message>
         <source>Other</source>
-        <translation> </translation>
+        <translation>Неопределен</translation>
     </message>
 </context>
 
@@ -2709,7 +2709,7 @@ ASiC-E – это разрабатываемый международный фо
     </message>
     <message>
         <source>Opening</source>
-        <translation>Открывание</translation>
+        <translation>Открывается</translation>
     </message>
     <message>
         <source>Signing</source>
@@ -2927,7 +2927,7 @@ ASiC-E – это разрабатываемый международный фо
 
     <message>
         <source>PIN Canceled</source>
-        <translation type="unfinished"></translation>
+        <translation>PIN-код отменен</translation>
     </message>
     <message>
         <source>PIN locked</source>
@@ -2939,15 +2939,15 @@ ASiC-E – это разрабатываемый международный фо
     </message>
     <message>
         <source>PKCS11 general error</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка PKCS11</translation>
     </message>
     <message>
         <source>PKCS11 device error</source>
-        <translation type="unfinished"></translation>
+        <translation>Ошибка PKCS11 устройства</translation>
     </message>
     <message>
         <source>PKCS11 unknown error</source>
-        <translation type="unfinished"></translation>
+        <translation>Неизвестная ошибка PKCS11</translation>
     </message>
 </context>
 
@@ -2977,15 +2977,15 @@ ASiC-E – это разрабатываемый международный фо
     </message>
     <message>
         <source>Signing/decrypting is already in progress another window.</source>
-        <translation type="unfinished"></translation>
+        <translation>Операция подписи/расшифровки уже выполняется в другом окне.></translation>
     </message>
     <message>
         <source>Authentication certificate is not selected.</source>
-        <translation type="unfinished"></translation>
+        <translation>Сертификат идентификации не выбран</translation>
     </message>
     <message>
         <source>Failed to decrypt document</source>
-        <translation type="unfinished"></translation>
+        <translation>Не удалось расшифровать документ</translation>
     </message>
 </context>
 

--- a/client/widgets/AddressItem.cpp
+++ b/client/widgets/AddressItem.cpp
@@ -79,31 +79,28 @@ AddressItem::AddressItem(const CKey &k, QWidget *parent, bool showIcon)
 			key.cert.subjectInfo("GN").value(0) + " " + key.cert.subjectInfo("SN").value(0) :
 			key.cert.subjectInfo("CN").value(0);
 
-	QString type;
-	QTextStream st(&type);
+	QString type, strDate;
 
 	auto certType = SslCertificate(key.cert).type();
 	if(certType & SslCertificate::DigiIDType)
-		st << tr("Digi-ID");
+		type = "Digi-ID";
 	else if(certType & SslCertificate::EstEidType)
-		st << tr("ID-card");
+		type = "ID-card";
 	else if(certType & SslCertificate::TempelType)
-		st << tr("e-Seal");
+		type = "e-Seal";
 	else if(certType & SslCertificate::MobileIDType)
-		st << tr("Mobile-ID");
+		type = "Mobile-ID";
 
 	if(!showIcon)
 	{
 		DateTime date(key.cert.expiryDate().toLocalTime());
 		if(!date.isNull())
 		{
-			if(!type.isEmpty())
-				st << " - ";
-			st << tr("Expires on") << " " << date.formatDate("dd. MMMM yyyy");
+			strDate = date.formatDate("dd. MMMM yyyy");
 		}
 	}
 
-	update(name, key.cert.subjectInfo("serialNumber").value(0), type, AddressItem::Remove);
+	update(name, key.cert.subjectInfo("serialNumber").value(0), type, strDate, AddressItem::Remove);
 }
 
 AddressItem::~AddressItem()
@@ -118,7 +115,8 @@ void AddressItem::changeEvent(QEvent* event)
 		ui->retranslateUi(this);
 
 		setName();
-		ui->idType->setText(tr(qPrintable(typeText)));
+
+		setIdType();
 	}
 
 	QWidget::changeEvent(event);
@@ -243,13 +241,30 @@ void AddressItem::stateChange(ContainerState state)
 	}
 }
 
-void AddressItem::update(const QString& cardName, const QString& cardCode, const QString& type, ShowToolButton show)
+void AddressItem::update(const QString& cardName, const QString& cardCode, const QString& type, const QString& strDate, ShowToolButton show)
 {
-	ui->idType->setText( tr(qPrintable(type)));
 	typeText = type;
+	expireDateText = strDate;
 	code = cardCode;
 	name = cardName;
 
+	setIdType();
 	showButton(show);
 	changeNameHeight();
+}
+
+void AddressItem::setIdType()
+{
+	QString str;
+	QTextStream st(&str);
+	st << tr(qPrintable(typeText));
+
+	if(!expireDateText.isEmpty())
+	{
+		if(!typeText.isEmpty())
+			st << " - ";
+		st << tr("Expires on") << " " << expireDateText;
+	}
+
+	ui->idType->setText(str);
 }

--- a/client/widgets/AddressItem.h
+++ b/client/widgets/AddressItem.h
@@ -52,7 +52,7 @@ public:
 	void idChanged(const QString& cardCode, const QString& mobileCode) override;
 	void showButton(ShowToolButton show);
 	void stateChange(ria::qdigidoc4::ContainerState state) override;
-	void update(const QString& name, const QString& code, const QString &type, ShowToolButton show);
+	void update(const QString& name, const QString& code, const QString &type, const QString& strDate, ShowToolButton show);
 
 protected:
 	void changeEvent(QEvent* event) override;
@@ -63,6 +63,7 @@ private:
 	void changeNameHeight();
 	void recalculate();
 	void setName();
+	void setIdType();
 
 	Ui::AddressItem *ui;
 
@@ -74,5 +75,6 @@ private:
 	int nameWidth;
 	int reservedWidth;
 	QString typeText;
+	QString expireDateText;
 	bool yourself;
 };


### PR DESCRIPTION
1. translate recepient item
2. fixed backgroung color of recepient info dialog.
3. fixed wrong Warning dialog height issue on OSX
4. Introduction page label height increased a bit (Russian text does not
  fit to, something should be cut anyway).
