### PR TITLE
Decrypted files logic

### DIFF
--- a/client/crypto/CryptoDoc.cpp
+++ b/client/crypto/CryptoDoc.cpp
@@ -1123,7 +1123,7 @@ QList<QString> CryptoDoc::files()
 
 bool CryptoDoc::move(const QString &to)
 {
-	if(containerState == ContainerState::UnencryptedContainer)
+	if(containerState & (ContainerState::UnencryptedContainer | ContainerState::DecryptedContainer))
 	{
 		d->fileName = to;
 		return true;

--- a/client/translations/en.ts
+++ b/client/translations/en.ts
@@ -488,11 +488,11 @@ Media type: %3</translation>
 
     <message>
         <source>Select folder where files will be stored</source>
-        <translation>*</translation>
+        <translation>Select folder where files will be stored</translation>
     </message>
     <message>
         <source>%1 already exists.&lt;br /&gt;Do you want replace it?</source>
-        <translation>*</translation>
+        <translation>%1 already exists.&lt;br /&gt;Do you want replace it?</translation>
     </message>
 </context>
 

--- a/client/widgets/AddressItem.cpp
+++ b/client/widgets/AddressItem.cpp
@@ -231,7 +231,7 @@ void AddressItem::showButton(ShowToolButton show)
 
 void AddressItem::stateChange(ContainerState state)
 {
-	if( state == UnencryptedContainer )
+	if( state & (UnencryptedContainer | DecryptedContainer))
 	{
 		ui->remove->show();
 	}

--- a/client/widgets/AddressItem.ui
+++ b/client/widgets/AddressItem.ui
@@ -29,6 +29,12 @@
     <bold>false</bold>
    </font>
   </property>
+  <property name="cursor">
+   <cursorShape>PointingHandCursor</cursorShape>
+  </property>
+  <property name="focusPolicy">
+   <enum>Qt::StrongFocus</enum>
+  </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
@@ -192,11 +198,17 @@ text-decoration: none solid rgb(0, 0, 0);
              <pointsize>14</pointsize>
             </font>
            </property>
+           <property name="mouseTracking">
+            <bool>true</bool>
+           </property>
            <property name="text">
             <string>MARI MAASIKAS MUSTIKAS 48405050123 (Sina ise)</string>
            </property>
            <property name="wordWrap">
             <bool>true</bool>
+           </property>
+           <property name="textInteractionFlags">
+            <set>Qt::NoTextInteraction</set>
            </property>
           </widget>
          </item>

--- a/client/widgets/ContainerPage.cpp
+++ b/client/widgets/ContainerPage.cpp
@@ -481,12 +481,12 @@ void ContainerPage::updatePanes(ContainerState state)
 		envelope = "Container";
 
 		resize = !ui->changeLocation->isHidden();
-		ui->changeLocation->hide();
+		ui->changeLocation->show();
 		ui->leftPane->init(fileName, "Decrypted files");
 		showRightPane( ItemAddress, "Recipients");
-		hideMainAction();
-		hideButtons( { ui->convert, ui->save } );
-		showButtons( { ui->cancel, ui->navigateToContainer, ui->email } );
+		showMainAction(EncryptContainer);
+		showButtons( { ui->cancel, ui->convert } );
+		hideButtons( { ui->save, ui->navigateToContainer, ui->email } );
 		break;
 	default:
 		// Uninitialized cannot be shown on container page

--- a/client/widgets/FileItem.cpp
+++ b/client/widgets/FileItem.cpp
@@ -86,6 +86,7 @@ void FileItem::stateChange(ContainerState state)
 
 	switch(state)
 	{
+	case DecryptedContainer:
 	case UnsignedSavedContainer:
 		ui->download->show();
 		ui->remove->show();
@@ -96,10 +97,6 @@ void FileItem::stateChange(ContainerState state)
 		break;
 	case EncryptedContainer:
 		ui->download->hide();
-		ui->remove->hide();
-		break;
-	case DecryptedContainer:
-		ui->download->show();
 		ui->remove->hide();
 		break;
 	default:

--- a/client/widgets/ItemList.cpp
+++ b/client/widgets/ItemList.cpp
@@ -287,7 +287,7 @@ void ItemList::setTerm(const QString &term)
 void ItemList::stateChange( ContainerState state )
 {
 	this->state = state;
-	ui->add->setVisible(state & (SignatureContainers | UnencryptedContainer));
+	ui->add->setVisible(state & (UnsignedContainer | UnsignedSavedContainer | UnencryptedContainer | DecryptedContainer));
 
 	for(auto item: items)
 	{


### PR DESCRIPTION
   1. Allow to drop files to client only if not signed/not encrypted container.
   2. Decrypted container logic as in digidoc3:
          - allow to add/remove/download files
	  - allow to add/remove recipients
      Allow encrypt/decrypt of same 'cdoc' many times.
   3. Show 'Pointing Hand' cursor for recipient item
   4. Add missing English translation.

Signed-off-by: Oleg Prokofjev oleg@aktors.ee