### PR TITLE
Make Win to use smaller 14 size font

### DIFF
--- a/client/Styles.cpp
+++ b/client/Styles.cpp
@@ -59,7 +59,7 @@ const FontSample regularSamples[] = {
 	{ 11, "Dokumendi haldamiseks sisesta kaart lugejasse", 233 },
 	{ 12, "Ver. 4.0.0.1", 57 },
 	{ 13, "Dokument2.pdf", 80 }, // Estimated
-	{ 14, "Dokument2.pdf", 96 },
+	{ 14, "Dokument2.pdf", 95 },
 	{ 15, "MARI MAASIKAS", 110 }, // Estimated
 	{ 16, "MARI MAASIKAS", 124 },
 	{ 18, "Isikutuvastamise sertifikaat", 221 },

--- a/client/dialogs/PinPopup.cpp
+++ b/client/dialogs/PinPopup.cpp
@@ -67,7 +67,7 @@ void PinPopup::init( PinDialog::PinFlags flags, const QString &title, TokenData:
 	setWindowModality( Qt::ApplicationModal );
 	setFixedSize( size() );
 
-	QFont regular = Styles::font( Styles::Regular, 13 );
+	QFont regular = Styles::font( Styles::Regular, 14 );
 	QFont condensed14 = Styles::font( Styles::Condensed, 14 );
 	
 	ui->labelNameId->setFont( Styles::font( Styles::Regular, 14 ) );


### PR DESCRIPTION
   PIN popup dialog to show 'one size bigger' text.

Signed-off-by: Oleg Prokofjev oleg@aktors.ee