### PR TITLE
Ask filesystem access in case of macOS signed app

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -26,7 +26,7 @@ if( UNIX AND NOT APPLE )
 endif()
 
 if( APPLE )
-	list( APPEND SOURCES Application_mac.mm )
+	list( APPEND SOURCES Application_mac.mm util/MacUtil.mm )
 	set_source_files_properties( Application_mac.mm PROPERTIES COMPILE_FLAGS "-fobjc-arc" )
 	list( APPEND ADDITIONAL_LIBRARIES "-framework Security" "-framework Quartz" )
 elseif( WIN32 )

--- a/client/translations/en.ts
+++ b/client/translations/en.ts
@@ -81,6 +81,18 @@
         <source>Create %1</source>
         <translation>Create %1</translation>
     </message>
+    <message>
+        <source>ALLOW_ACCESS</source>
+        <translation>App Store applications on macOS require user to explicitly give access to the file system.&lt;br /&gt;Allow access to folder '%1' or specify alternative location where to save the envelope.</translation>
+    </message>
+    <message>
+        <source>CANCEL</source>
+        <translation>CANCEL</translation>
+    </message>
+    <message>
+        <source>ALLOW</source>
+        <translation>ALLOW</translation>
+    </message>
 </context>
 
 

--- a/client/translations/et.ts
+++ b/client/translations/et.ts
@@ -81,6 +81,18 @@
         <source>Create %1</source>
         <translation>Loo %1</translation>
     </message>
+    <message>
+        <source>ALLOW_ACCESS</source>
+        <translation>App Store rakenduste ligipääs failisüsteemile on piiratud ning kasutaja peab valima kataloogi millele rakendus ligi pääseb.&lt;br /&gt;Luba rakendusele kataloogile '%1' ligi pääseda või vali teine kataloog kuhu ümbrik salvestada.</translation>
+    </message>
+    <message>
+        <source>CANCEL</source>
+        <translation>KATKESTA</translation>
+    </message>
+    <message>
+        <source>ALLOW</source>
+        <translation>LUBA</translation>
+    </message>
 </context>
 
 

--- a/client/translations/ru.ts
+++ b/client/translations/ru.ts
@@ -81,6 +81,18 @@
         <source>Create %1</source>
         <translation>Создайте %1</translation>
     </message>
+    <message>
+        <source>ALLOW_ACCESS</source>
+        <translation>App Store приложения на macOS требуют, чтобы пользователь позволил доступ к файловой системе.&lt;br /&gt;Разрешите доступ к папке '%1' или укажите альтернативное место для сохранения конверта.</translation>
+    </message>
+    <message>
+        <source>CANCEL</source>
+        <translation>ОТМЕНА</translation>
+    </message>
+    <message>
+        <source>ALLOW</source>
+        <translation>ПОЗВОЛИТЬ</translation>
+    </message>
 </context>
 
 

--- a/client/util/MacUtil.h
+++ b/client/util/MacUtil.h
@@ -1,0 +1,33 @@
+/*
+ * QDigiDoc4
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#pragma once
+
+namespace ria
+{
+namespace qdigidoc4
+{
+	class MacUtil
+	{
+	public:
+		static void bookmark(char const* path);
+		static bool isWritable(char const* path);
+	};
+}
+}

--- a/client/util/MacUtil.mm
+++ b/client/util/MacUtil.mm
@@ -1,0 +1,108 @@
+/*
+ * QDigiDoc4
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include "MacUtil.h"
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
+#include <common/Settings.h>
+#include <QByteArray>
+#include <string>
+
+namespace ria
+{
+namespace qdigidoc4
+{
+
+NSData* toNSData(const QByteArray& data)
+{
+	return [NSData dataWithBytes:data.constData() length:data.size()];
+}
+
+QByteArray toByteArray(const NSData *data)
+{
+	QByteArray ba;
+	ba.resize([data length]);
+	[data getBytes:ba.data() length:ba.size()];
+	return ba;
+}
+
+void MacUtil::bookmark(char const* path)
+{
+	std::string url;
+	url.append("file://");
+	url.append(path);
+	
+	char const* url_path = url.c_str();
+	NSString *folder = [NSString stringWithUTF8String:url_path];
+	NSURL *fileURL = [NSURL URLWithString:folder];
+
+	NSError *error = nil;
+	NSData *bookmark = [fileURL bookmarkDataWithOptions:NSURLBookmarkCreationWithSecurityScope
+			includingResourceValuesForKeys:nil
+							relativeToURL:nil
+									error:&error];
+	if (error)
+	{
+		NSLog(@"MacUtil - Error creating bookmark for URL (%@): %@", folder, error);
+	}
+	else
+	{
+		NSLog(@"MacUtil - Created bookmark for URL (%@)", folder);
+		Settings settings;
+		QVariantMap bookmarks = settings.value("BookmarkedFolders").toMap();
+		bookmarks[url_path] = toByteArray(bookmark);
+		settings.setValue("BookmarkedFolders", bookmarks);
+	}
+}
+
+bool MacUtil::isWritable(char const* path)
+{
+	// https://stackoverflow.com/questions/12153504/accessing-the-desktop-in-a-sandboxed-app
+	std::string url;
+	url.append("file://");
+	url.append(path);
+
+	char const* url_path = url.c_str();
+
+	NSString *folder = [NSString stringWithUTF8String:url_path];
+	NSURL *bookmarkedURL = [NSURL URLWithString:folder];
+	BOOL ok = [bookmarkedURL startAccessingSecurityScopedResource];
+	NSLog(@"MacUtil - Accessed ok: %d URL (%@)", ok, folder);
+
+	if(!ok)
+	{
+		Settings settings;
+		QVariantMap bookmarks = settings.value("BookmarkedFolders").toMap();
+		if(bookmarks.contains(url_path))
+		{
+			NSData *bookmark = toNSData(bookmarks[url_path].toByteArray());
+			NSError *error = nil;
+			bookmarkedURL = [NSURL URLByResolvingBookmarkData:bookmark options:NSURLBookmarkResolutionWithSecurityScope
+				relativeToURL:nil bookmarkDataIsStale:nil error:&error];
+			ok = [bookmarkedURL startAccessingSecurityScopedResource];
+			NSLog(@"MacUtil - Accessed bookmark ok: %d URL (%@)", ok, folder);
+		}
+	}
+
+	return ok;
+}
+
+}; // namespace qdigidoc4
+}; // namespace ria


### PR DESCRIPTION
macOS App Store apps have limited rights to access the filesystem. If the accessed file is not in the application's sandbox, the user must explicitly grant access to the filesystem.

- App asks permission to write data (signature- & crypto-containers) to the file system
- Folder where permission is given is saved as a bookmark
- Bookmarks are checked on the next access to the filesystem: if folder or its parent is bookmarked, access is automatically granted

Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>