### PR TITLE
Show summary of signature errors instead of details

### DIFF
--- a/client/MainWindow.cpp
+++ b/client/MainWindow.cpp
@@ -321,7 +321,7 @@ bool MainWindow::closeWarning(WarningItem *warning, bool force)
 	{
 		warnings.removeOne(warning);
 		warning->close();
-		delete warning;
+		warning->deleteLater();
 		updateWarnings();
 
 		return true;
@@ -1427,6 +1427,8 @@ void MainWindow::warningClicked(const QString &link)
 		ui->accordion->changePin1Clicked (false, true);
 	else if(link == "#unblock-PIN2")
 		ui->accordion->changePin2Clicked (false, true);
+	else if(link.startsWith("http"))
+		QDesktopServices::openUrl(QUrl(link));
 }
 
 bool MainWindow::wrapContainer(bool signing)

--- a/client/translations/en.ts
+++ b/client/translations/en.ts
@@ -794,6 +794,10 @@ Learn more info here:</translation>
         <translation>http://id.ee/?lang=en&amp;id=34317</translation>
     </message>
     <message>
+        <source>https://www.id.ee/index.php?id=30591</source>
+        <translation>https://www.id.ee/index.php?id=30591</translation>
+    </message>
+    <message>
         <source>Signed on</source>
         <translation>Signed on</translation>
     </message>

--- a/client/translations/en.ts
+++ b/client/translations/en.ts
@@ -775,6 +775,24 @@ Learn more info here:</translation>
         <source>is unknown</source>
         <translation>is unknown</translation>
     </message>
+    <message numerus="yes">
+        <source>%n signatures are not valid</source>
+        <translation>
+            <numerusform>%n signature is not valid</numerusform>
+            <numerusform>%n signatures are not valid</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n signatures are unknown</source>
+        <translation>
+            <numerusform>%n signature is unknown</numerusform>
+            <numerusform>%n signatures are unknown</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>http://id.ee/?lang=en&amp;id=34317</source>
+        <translation>http://id.ee/?lang=en&amp;id=34317</translation>
+    </message>
     <message>
         <source>Signed on</source>
         <translation>Signed on</translation>

--- a/client/translations/et.ts
+++ b/client/translations/et.ts
@@ -795,6 +795,10 @@ Rohkem infot leiate siit:</translation>
         <translation>https://www.id.ee/?lang=et&amp;id=34054</translation>
     </message>
     <message>
+        <source>https://www.id.ee/index.php?id=30591</source>
+        <translation>https://www.id.ee/index.php?id=30573</translation>
+    </message>
+    <message>
         <source>Signed on</source>
         <translation>Allkirjastatud</translation>
     </message>

--- a/client/translations/et.ts
+++ b/client/translations/et.ts
@@ -776,6 +776,24 @@ Rohkem infot leiate siit:</translation>
         <source>is unknown</source>
         <translation>on teadmata</translation>
     </message>
+    <message numerus="yes">
+        <source>%n signatures are not valid</source>
+        <translation>
+            <numerusform>%n allkiri ei ole kehtiv</numerusform>
+            <numerusform>%n allkirja ei ole kehtivad</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n signatures are unknown</source>
+        <translation>
+            <numerusform>%n allkiri on teadmata</numerusform>
+            <numerusform>%n allkirja on teadmata</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>http://id.ee/?lang=en&amp;id=34317</source>
+        <translation>https://www.id.ee/?lang=et&amp;id=34054</translation>
+    </message>
     <message>
         <source>Signed on</source>
         <translation>Allkirjastatud</translation>
@@ -1970,7 +1988,7 @@ Täiendavad litsentsid ja komponendid</translation>
     </message>
     <message>
         <source>Signature status is displayed "unknown" if you don't have all validity confirmation service certificates and/or certificate authority certificates installed into your computer (&lt;a href='http://id.ee/?lang=en&amp;id=34317'&gt;additional information&lt;/a&gt;).</source>
-        <translation>Allkirja olek kuvatakse "teadmataks", kui teil pole teie arvutisse installitud kõiki kehtivuskinnituse teenuse sertifikaate ja / või sertifikaadi sertifikaadi sertifikaate (&lt;a href='http://id.ee/?lang=en&amp;id=34317'&gt;lisainformatsioon&lt;/a&gt;).</translation>
+        <translation>Allkirja olek kuvatakse "teadmataks", kui teil pole teie arvutisse installitud kõiki kehtivuskinnituse teenuse sertifikaate ja / või sertifikaadi sertifikaadi sertifikaate (&lt;a href='https://www.id.ee/?lang=et&amp;id=34054'&gt;lisainformatsioon&lt;/a&gt;).</translation>
     </message>
     <message>
         <source>Signer&apos;s Certificate issuer</source>

--- a/client/translations/ru.ts
+++ b/client/translations/ru.ts
@@ -770,6 +770,26 @@ Learn more info here:</source>
         <source>is unknown</source>
         <translation>неизвестно</translation>
     </message>
+    <message numerus="yes">
+        <source>%n signatures are not valid</source>
+        <translation>
+            <numerusform>%n подпись не действует</numerusform>
+            <numerusform>%n подписи недействительны</numerusform>
+            <numerusform>%n подписи недействительны</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%n signatures are unknown</source>
+        <translation>
+            <numerusform>%n подпись неизвестна</numerusform>
+            <numerusform>%n подписи неизвестны</numerusform>
+            <numerusform>%n подписи неизвестны</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>http://id.ee/?lang=en&amp;id=34317</source>
+        <translation>http://id.ee/?lang=ru&amp;id=34529</translation>
+    </message>
     <message>
         <source>Signed on</source>
         <translation>Подписано</translation>
@@ -1107,7 +1127,7 @@ Learn more info here:</source>
     </message>
     <message>
         <source>By entering the PIN2 code, you will have signed the document with digital signature that by law is equal to the signature signed by hand. You will find the PIN2 code in the envelope that came with your ID-card or Mobile-ID.</source>
-        <translation>Введя PIN2 код, вы подписываете документ цифровой подписью, которая по закону равносильна подписи «от руки». PIN2 код Вы найдете в конверте, который прилагается к Вашей ID-карте или Mobiili-ID.</translation>
+        <translation>Введя PIN2 код, вы подписываете документ цифровой подписью, которая по закону равносильна подписи «от руки». PIN2 код Вы найдете в конверте, который прилагается к Вашей ID-карте или Mobiil-ID.</translation>
     </message>
     <message>
         <source>How to encrypt documents?</source>
@@ -3025,7 +3045,7 @@ ASiC-E – это разрабатываемый международный фо
     <message>
         <source>SignatureMobile</source>
         <translation>ПОДПИСАТЬ С
-MOBIIL_ID</translation>
+MOBIIL-ID</translation>
     </message>
     <message>
         <source>SignatureAdd</source>

--- a/client/translations/ru.ts
+++ b/client/translations/ru.ts
@@ -791,6 +791,10 @@ Learn more info here:</source>
         <translation>http://id.ee/?lang=ru&amp;id=34529</translation>
     </message>
     <message>
+        <source>https://www.id.ee/index.php?id=30591</source>
+        <translation>https://www.id.ee/index.php?id=30604</translation>
+    </message>
+    <message>
         <source>Signed on</source>
         <translation>Подписано</translation>
     </message>

--- a/client/widgets/SignatureItem.cpp
+++ b/client/widgets/SignatureItem.cpp
@@ -68,11 +68,12 @@ void SignatureItem::init()
 {
 	const SslCertificate cert = signature.cert();
 
-	QString accessibility, signingInfo;
+	QString accessibility, signingInfo, status;
+	link = QString();
 	name = QString();
 	serial = QString();
-	status = QString();
 	statusHtml = QString();
+	error = QString();
 
 	QTextStream sa(&accessibility);
 	QTextStream sc(&statusHtml);
@@ -121,10 +122,14 @@ void SignatureItem::init()
 		sc << "<font color=\"green\">" << label << " " << tr("is valid") << "</font> <font>(" << tr("Test signature") << ")";
 		break;
 	case DigiDocSignature::Invalid:
+		error = "%n signatures are not valid";
+		link = "http://id.ee/?lang=en&id=34317";
 		sa << tr("is not valid");
 		sc << "<font color=\"red\">" << label << " " << tr("is not valid");
 		break;
 	case DigiDocSignature::Unknown:
+		error = "%n signatures are unknown";
+		link = "http://id.ee/?lang=en&id=34317";
 		sa << tr("is unknown");
 		sc << "<font color=\"red\">" << label << " " << tr("is unknown");
 		break;
@@ -156,7 +161,9 @@ void SignatureItem::init()
 	setAccessibleName(label + " " + cert.toString(cert.showCN() ? "CN" : "GN SN"));
 	setAccessibleDescription( accessibility );
 
-	recalculate();
+	// Reserved width: signature icon (24px) + remove icon (19px) + 5px margin before remove
+	reservedWidth = ICON_WIDTH + 5 + (ui->remove->isHidden() ? 0 : ICON_WIDTH + 5);
+	nameWidth = nameMetrics->width(name  + " - " + status);
 	changeNameHeight();
 }
 
@@ -199,14 +206,14 @@ void SignatureItem::details()
 	dlg.exec();
 }
 
-QString SignatureItem::getName() const
+QString SignatureItem::getError() const
 {
-	return name;
+	return error;
 }
 
-QString SignatureItem::getStatus() const
+QString SignatureItem::getLink() const
 {
-	return status;
+	return link;
 }
 
 QString SignatureItem::id() const
@@ -227,13 +234,6 @@ bool SignatureItem::isSelfSigned(const QString& cardCode, const QString& mobileC
 void SignatureItem::mouseReleaseEvent(QMouseEvent *event)
 {
 	details();
-}
-
-void SignatureItem::recalculate()
-{
-	// Reserved width: signature icon (24px) + remove icon (19px) + 5px margin before remove
-	reservedWidth = ICON_WIDTH + 5 + (ui->remove->isHidden() ? 0 : ICON_WIDTH + 5);
-	nameWidth = nameMetrics->width(name  + " - " + status);
 }
 
 QString SignatureItem::red(const QString &text)

--- a/client/widgets/SignatureItem.cpp
+++ b/client/widgets/SignatureItem.cpp
@@ -123,7 +123,7 @@ void SignatureItem::init()
 		break;
 	case DigiDocSignature::Invalid:
 		error = "%n signatures are not valid";
-		link = "http://id.ee/?lang=en&id=34317";
+		link = "https://www.id.ee/index.php?id=30591";
 		sa << tr("is not valid");
 		sc << "<font color=\"red\">" << label << " " << tr("is not valid");
 		break;

--- a/client/widgets/SignatureItem.h
+++ b/client/widgets/SignatureItem.h
@@ -38,8 +38,8 @@ public:
 	explicit SignatureItem(const DigiDocSignature &s, ria::qdigidoc4::ContainerState state, bool isSupported, QWidget *parent = nullptr);
 	~SignatureItem();
 
-	QString getName() const;
-	QString getStatus() const;
+	QString getError() const;
+	QString getLink() const;
 	QString id() const override;
 	bool isInvalid() const;
 	bool isSelfSigned(const QString& cardCode, const QString& mobileCode) const;
@@ -55,7 +55,6 @@ protected:
 private:
 	void changeNameHeight();
 	void init();
-	void recalculate();
 	QString red(const QString &text);
 	void removeSignature();
 	void setIcon(const QString &icon, int width = 17, int height = 20);
@@ -67,9 +66,10 @@ private:
 	bool invalid;
 	int nameWidth;
 	int reservedWidth;
+	QString error;
+	QString link;
 	QString name;
 	QString serial;
-	QString status;
 	QString statusHtml;
 	std::unique_ptr<QFontMetrics> nameMetrics;
 };


### PR DESCRIPTION
Show summary of errors on the warning ribbon instead of error for each
invalid signature; same errors are grouped with count.

Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>