### PR TITLE
Always open encapsulated container in new window

### DIFF
--- a/client/Application.cpp
+++ b/client/Application.cpp
@@ -804,7 +804,7 @@ void Application::showClient(const QStringList &params, bool crypto)
 {
 	QWidget *w = nullptr;
 	MainWindow *main = qobject_cast<MainWindow*>(qApp->uniqueRoot());
-	if(main && ((!crypto && main->digiDocPath().isEmpty()) || (crypto && main->cryptoPath().isEmpty())))
+	if(main && main->digiDocPath().isEmpty() && main->cryptoPath().isEmpty())
 		w = main;
 	if( !w )
 	{

--- a/client/MainWindow.cpp
+++ b/client/MainWindow.cpp
@@ -724,15 +724,6 @@ void MainWindow::onCryptoAction(int action, const QString &id, const QString &ph
 
 void MainWindow::openFile(const QString &file)
 {
-	ExtensionType ext = FileUtil::extension(file);
-
-	// If possible open the file in same main window
-	if((ext == ExtensionType::ExtSignature && !digiDoc) || (ext == ExtensionType::ExtCrypto && !cryptoDoc))
-	{
-		openFiles(QStringList(file));
-		return;
-	}
-
 	QDesktopServices::openUrl(QUrl::fromLocalFile(file));
 }
 


### PR DESCRIPTION
DDKLIEN-32: Always open encapsulated BDOC / ASiC-E / ASiC-S /CDOC in new window 
instead of another tab in the same window

Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>