### PR TITLE
Fix for DDKLIEN-69_71

### DIFF
--- a/client/MainWindow.cpp
+++ b/client/MainWindow.cpp
@@ -1503,7 +1503,7 @@ void MainWindow::showIdCardAlerts(const QSmartCardData& t)
 		t.version() == QSmartCardData::VER_3_4 &&
 		(!t.authCert().validateEncoding() || !t.signCert().validateEncoding()))
 	{
-		qApp->showWarning( tr("Your ID-card certificates cannot be renewed starting from 01.07.2017. Your document is still valid until its expiring date and it can be used to login to e-services and give digital signatures. If there are problems using Your ID-card in e-services please contact ID-card helpdesk by phone (+372) 677 3377 or visit Police and Border Guard Board service point.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;http://id.ee/?id=30519&amp;read=38011&quot;&gt;More info&lt;/a&gt;"));
+		qApp->showWarning( tr("Your ID-card certificates cannot be renewed starting from 01.07.2017."));
 	}
 	qApp->smartcard()->setProperty("lastcard", t.card());
 

--- a/client/MainWindow_MyEID.cpp
+++ b/client/MainWindow_MyEID.cpp
@@ -84,7 +84,7 @@ bool MainWindow::checkExpiration()
 	}
 
 	if(expiresIn <= 0)
-		showWarning(WarningText(WarningItem::tr("Certificates have expired!"), "", -1, CERT_EXPIRY_WARNING));
+		showWarning(WarningText(WarningItem::tr("Certificates have expired!"), "", -1, CERT_EXPIRED_WARNING));
 	else if(expiresIn <= 105)
 		showWarning(WarningText(WarningItem::tr("Certificates expire soon!"), "", -1, CERT_EXPIRY_WARNING));
 

--- a/client/dialogs/AddRecipients.cpp
+++ b/client/dialogs/AddRecipients.cpp
@@ -60,6 +60,7 @@ QDialog(parent)
 
 AddRecipients::~AddRecipients()
 {
+	QApplication::restoreOverrideCursor();
 	delete ui;
 }
 

--- a/client/dialogs/SettingsDialog.cpp
+++ b/client/dialogs/SettingsDialog.cpp
@@ -89,6 +89,7 @@ SettingsDialog::SettingsDialog(int page, QWidget *parent, QString appletVersion)
 
 SettingsDialog::~SettingsDialog()
 {
+	QApplication::restoreOverrideCursor();
 	delete ui;
 }
 
@@ -262,6 +263,7 @@ void SettingsDialog::initUI()
 	connect( ui->btnMenuInfo, &QPushButton::clicked, this, [this](){ changePage(ui->btnMenuInfo); ui->stackedWidget->setCurrentIndex(5); } );
 
 	connect( this, &SettingsDialog::finished, this, &SettingsDialog::save );
+	connect( this, &SettingsDialog::finished, this, [this](){ QApplication::restoreOverrideCursor(); } );
 
 	connect( ui->btGeneralChooseDirectory, &QPushButton::clicked, this, &SettingsDialog::openDirectory );
 }

--- a/client/dialogs/SignatureDialog.cpp
+++ b/client/dialogs/SignatureDialog.cpp
@@ -52,16 +52,17 @@ SignatureDialog::SignatureDialog(const DigiDocSignature &signature, QWidget *par
 	SslCertificate c = signature.cert();
 	QString style = "<font color=\"green\">";
 	QString status = tr("Signature");
-	if(signature.profile() == "TimeStampToken")
+	bool	isTS = (signature.profile() == "TimeStampToken") ? true : false;
+	if(isTS)
 		status = tr("Timestamp");
 	status += " ";
 	switch( s.validate() )
 	{
 	case DigiDocSignature::Valid:
-		status += tr("is valid");
+		status += tr("is valid", isTS ? "Timestamp" : "Signature");
 		break;
 	case DigiDocSignature::Warning:
-		status += QString("%1%2 <font color=\"gold\">(%3)").arg(tr("is valid"), STYLE_TERMINATOR, tr("Warnings"));
+		status += QString("%1%2 <font color=\"gold\">(%3)").arg(tr("is valid", isTS ? "Timestamp" : "Signature"), STYLE_TERMINATOR, tr("Warnings"));
 		if( !s.lastError().isEmpty() )
 			d->error->setPlainText( s.lastError() );
 		if( s.warning() & DigiDocSignature::DigestWeak )
@@ -72,14 +73,14 @@ SignatureDialog::SignatureDialog(const DigiDocSignature &signature, QWidget *par
 		}
 		break;
 	case DigiDocSignature::NonQSCD:
-		status += QString("%1%2 <font color=\"gold\">(%3)").arg(tr("is valid"), STYLE_TERMINATOR, tr("Restrictions"));
+		status += QString("%1%2 <font color=\"gold\">(%3)").arg(tr("is valid", isTS ? "Timestamp" : "Signature"), STYLE_TERMINATOR, tr("Restrictions"));
 		decorateNotice("gold");
 		d->info->setText( tr(
 			"This e-Signature is not equivalent with handwritten signature and therefore "
 			"can be used only in transactions where Qualified e-Signature is not required.") );
 		break;
 	case DigiDocSignature::Test:
-		status += QString("%1 (%2)").arg(tr("is valid"), tr("Test signature"));
+		status += QString("%1 (%2)").arg(tr("is valid", isTS ? "Timestamp" : "Signature"), tr("Test signature"));
 		if( !s.lastError().isEmpty() )
 			d->error->setPlainText( s.lastError() );
 		d->info->setText( tr(
@@ -90,7 +91,7 @@ SignatureDialog::SignatureDialog(const DigiDocSignature &signature, QWidget *par
 		break;
 	case DigiDocSignature::Invalid:
 		style = "<font color=\"red\">";
-		status += tr("is not valid");
+		status += tr("is not valid", isTS ? "Timestamp" : "Signature");
 		d->error->setPlainText( s.lastError().isEmpty() ? tr("Unknown error") : s.lastError() );
 		decorateNotice("red");
 		d->info->setText( tr(
@@ -98,7 +99,7 @@ SignatureDialog::SignatureDialog(const DigiDocSignature &signature, QWidget *par
 		break;
 	case DigiDocSignature::Unknown:
 		style = "<font color=\"red\">";
-		status += tr("is unknown");
+		status += tr("is unknown", isTS ? "Timestamp" : "Signature");
 		d->error->setPlainText( s.lastError().isEmpty() ? tr("Unknown error") : s.lastError() );
 		decorateNotice("red");
 		d->info->setText( tr(

--- a/client/translations/en.ts
+++ b/client/translations/en.ts
@@ -482,20 +482,20 @@ Media type: %3</translation>
         <translation>Add files</translation>
     </message>
     <message>
-        <source>CANCEL</source>
-        <translation>CANCEL</translation>
+        <source>NO</source>
+        <translation>NO</translation>
     </message>
     <message>
         <source>YES</source>
         <translation>YES</translation>
     </message>
     <message>
-        <source>NO</source>
-        <translation>NO</translation>
+        <source>SAVE WITH OTHER NAME</source>
+        <translation>SAVE WITH OTHER NAME</translation>
     </message>
     <message>
-        <source>YES TO ALL</source>
-        <translation>YES TO ALL</translation>
+        <source>REPLACE ALL</source>
+        <translation>REPLACE ALL</translation>
     </message>
 
     <message>

--- a/client/translations/en.ts
+++ b/client/translations/en.ts
@@ -902,8 +902,8 @@ Learn more info here:</translation>
         <translation>CHANGE PUK</translation>
     </message>
     <message>
-        <source>%1PUK code is blocked because the PUK code has been entered 3 times incorrectly. Unable to disable the PUK code itself. %2 As long as the PUK code is blocked, all eID options can be used, except PUK code. %2You can only use the new PUK code with the new code envelope that you can use%3 from PPA%4.</source>
-        <translation>%1PUK code is blocked because the PUK code has been entered 3 times incorrectly. Unable to disable the PUK code itself. %2 As long as the PUK code is blocked, all eID options can be used, except PUK code. %2You can only use the new PUK code with the new code envelope that you can use%3 from PPA%4.</translation>
+        <source>PUK code is blocked because the PUK code has been entered 3 times incorrectly. Unable to disable the PUK code itself. As long as the PUK code is blocked, all eID options can be used, except PUK code. You can only use the new PUK code with the new code envelope that you can use from PPA.</source>
+        <translation>PUK code is blocked because the PUK code has been entered 3 times incorrectly. Unable to disable the PUK code itself. &lt;br&gt;&lt;br&gt;As long as the PUK code is blocked, all eID options can be used, except PUK code. &lt;br&gt;&lt;br&gt;You can only use the new PUK code with the new code envelope that you can use &lt;a href='https://www.politsei.ee/en/nouanded/isikut-toendavad-dokumendid/kui-id-kaardi-koodid-kaovad.dot'&gt;from PPA&lt;/a&gt;.</translation>
     </message>
 </context>
 
@@ -2382,7 +2382,7 @@ Additional licenses and components</translation>
         <translation>CONTINUE</translation>
     </message>
     <message>
-        <source>Your ID-card certificates cannot be renewed starting from 01.07.2017. Your document is still valid until its expiring date and it can be used to login to e-services and give digital signatures. If there are problems using Your ID-card in e-services please contact ID-card helpdesk by phone (+372) 677 3377 or visit Police and Border Guard Board service point.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;http://id.ee/?id=30519&amp;read=38011&quot;&gt;More info&lt;/a&gt;</source>
+        <source>Your ID-card certificates cannot be renewed starting from 01.07.2017.</source>
         <translation>Your ID-card certificates cannot be renewed starting from 01.07.2017. Your document is still valid until its expiring date and it can be used to login to e-services and give digital signatures. If there are problems using Your ID-card in e-services please contact ID-card helpdesk by phone (+372) 677 3377 or visit Police and Border Guard Board service point.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;http://id.ee/?id=30519&amp;read=38011&quot;&gt;More info&lt;/a&gt;</translation>
     </message>
     <message>

--- a/client/translations/et.ts
+++ b/client/translations/et.ts
@@ -903,8 +903,8 @@ Rohkem infot leiate siit:</translation>
         <translation>MUUDA PUK</translation>
     </message>
     <message>
-        <source>%1PUK code is blocked because the PUK code has been entered 3 times incorrectly. Unable to disable the PUK code itself. %2 As long as the PUK code is blocked, all eID options can be used, except PUK code. %2You can only use the new PUK code with the new code envelope that you can use%3 from PPA%4.</source>
-        <translation>%1PUK kood on blokeeritud, kuna PUK koodi on sisestatud 3 korda valesti. PUK koodi ei saa ise lahti blokeerida. %2Kuigi PUK kood on blokeeritud, saab kõiki eID võimalusi kasutada, välja arvatud PUK koodi vajavaid. %2Uue PUK koodi saad vaid uue koodiümbrikuga, mida %3taotle PPA-st%4.</translation>
+        <source>PUK code is blocked because the PUK code has been entered 3 times incorrectly. Unable to disable the PUK code itself. As long as the PUK code is blocked, all eID options can be used, except PUK code. You can only use the new PUK code with the new code envelope that you can use from PPA.</source>
+        <translation>PUK kood on blokeeritud, kuna PUK koodi on sisestatud 3 korda valesti. PUK koodi ei saa ise lahti blokeerida. &lt;br&gt;&lt;br&gt;Kuigi PUK kood on blokeeritud, saab kõiki eID võimalusi kasutada, välja arvatud PUK koodi vajavaid. &lt;br&gt;&lt;br&gt;Uue PUK koodi saad vaid uue koodiümbrikuga, mida &lt;a href='https://www.politsei.ee/et/nouanded/id-kaart-ja-pass/kui-id-kaardi-koodid-kaovad/'&gt;taotle PPA-st&lt;/a&gt;.</translation>
     </message>
 </context>
 
@@ -2365,8 +2365,8 @@ Täiendavad litsentsid ja komponendid</translation>
         <translation>EDASI</translation>
     </message>
     <message>
-        <source>Your ID-card certificates cannot be renewed starting from 01.07.2017. Your document is still valid until its expiring date and it can be used to login to e-services and give digital signatures. If there are problems using Your ID-card in e-services please contact ID-card helpdesk by phone (+372) 677 3377 or visit Police and Border Guard Board service point.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;http://id.ee/?id=30519&amp;read=38011&quot;&gt;More info&lt;/a&gt;</source>
-        <translation>Teie ID-kaardi sertifikaate ei saa uuendada alates 01.07.2017. Teie dokument on endiselt kehtiv kuni selle aegumiskuupäevani ja seda saab kasutada e-teenuste sisselogimiseks ja digitaalallkirjade saamiseks. Kui teie ID-kaardi kasutamine e-teenustes on probleeme, võtke palun ühendust ID-kaardi kasutajatoega telefonil (+372) 677 3377 või külastage politsei- ja piirivalveteenistuse teeninduspunkti.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;http://id.ee/?id=30519&amp;read=38011&quot;&gt;Lisateave&lt;/a&gt;</translation>
+        <source>Your ID-card certificates cannot be renewed starting from 01.07.2017.</source>
+        <translation>Teie ID-kaardi sertifikaate ei ole võimalik alates 01.07.2017 uuendada. Dokument kehtib oma kehtivusaja lõpuni ning sellega saab endiselt e-teenustesse sisse logida ning digiallkirja anda. Kui e-teenuste kasutamisel tekib tõrkeid, helistage ID-kaardi infotelefonile numbril 1777 või pöörduge Politsei- ja Piirivalveameti teeninduspunkti.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;http://id.ee/?id=30007&amp;read=38010&quot;&gt;Lisainfo&lt;/a&gt;</translation>
     </message>
     <message>
         <source>Certificate is not registered in the certificate store. Register now?</source>

--- a/client/translations/et.ts
+++ b/client/translations/et.ts
@@ -483,20 +483,20 @@ Tüüp: %3</translation>
         <translation>Lisa faile</translation>
     </message>
     <message>
-        <source>CANCEL</source>
-        <translation>KATKESTA</translation>
+        <source>NO</source>
+        <translation>EI</translation>
     </message>
     <message>
         <source>YES</source>
         <translation>JAH</translation>
     </message>
     <message>
-        <source>NO</source>
-        <translation>EI</translation>
+        <source>SAVE WITH OTHER NAME</source>
+        <translation>SALVESTA TEISE NIMEGA</translation>
     </message>
     <message>
-        <source>YES TO ALL</source>
-        <translation>JAH KÕIGILE</translation>
+        <source>REPLACE ALL</source>
+        <translation>KIRJUTA KÕIK ÜLE</translation>
     </message>
 
     <message>
@@ -2002,11 +2002,11 @@ Täiendavad litsentsid ja komponendid</translation>
     </message>
     <message>
         <source>This is an invalid signature or malformed digitally signed file. The signature is not valid.</source>
-        <translation>See on vigane allkiri või vigane digitaalselt allkirjastatud fail. Allkiri ei kehti.</translation>
+        <translation>See allkiri või allkirjastatud fail on vigane. Allkiri ei ole kehtiv.</translation>
     </message>
     <message>
         <source>Signature status is displayed "unknown" if you don't have all validity confirmation service certificates and/or certificate authority certificates installed into your computer (&lt;a href='http://id.ee/?lang=en&amp;id=34317'&gt;additional information&lt;/a&gt;).</source>
-        <translation>Allkirja olek kuvatakse "teadmataks", kui teil pole teie arvutisse installitud kõiki kehtivuskinnituse teenuse sertifikaate ja / või sertifikaadi sertifikaadi sertifikaate (&lt;a href='https://www.id.ee/?lang=et&amp;id=34054'&gt;lisainformatsioon&lt;/a&gt;).</translation>
+		<translation>Allkirja staatust kuvatakse &quot;teadmata&quot;, kui teie arvitisse pole lisatud kõiki kehtivuskinnituse teenuse sertifikaate ja/või nende kontrolliks vajalikke sertifikaate (&lt;a href=&apos;http://www.id.ee/?id=35939&apos;&gt;lisainformatsioon&lt;/a&gt;).</translation>
     </message>
     <message>
         <source>Signer&apos;s Certificate issuer</source>

--- a/client/translations/ru.ts
+++ b/client/translations/ru.ts
@@ -482,20 +482,20 @@ Media type: %3</source>
         <translation>Добавить файлы</translation>
     </message>
     <message>
-        <source>CANCEL</source>
-        <translation>ОТМЕНА</translation>
+        <source>NO</source>
+        <translation>НЕТ</translation>
     </message>
     <message>
         <source>YES</source>
         <translation>ДА</translation>
     </message>
     <message>
-        <source>NO</source>
-        <translation>НЕТ</translation>
+        <source>SAVE WITH OTHER NAME</source>
+        <translation>СОХРАНИТЬ ПОД ДРУГИМ ИМЕНЕМ</translation>
     </message>
     <message>
-        <source>YES TO ALL</source>
-        <translation>ДА ДЛЯ ВСЕХ</translation>
+        <source>REPLACE ALL</source>
+        <translation>ЗАМЕНИТЬ ВСЕ</translation>
     </message>
 
     <message>
@@ -797,7 +797,7 @@ Learn more info here:</source>
     <message numerus="yes">
         <source>%n timestamps are unknown</source>
         <translation>
-            <numerusform>%n временной штамп неизвестна</numerusform>
+            <numerusform>%n временной штамп неизвестен</numerusform>
             <numerusform>%n временных штампов неизвестны</numerusform>
             <numerusform>%n временных штампов неизвестны</numerusform>
         </translation>

--- a/client/translations/ru.ts
+++ b/client/translations/ru.ts
@@ -760,20 +760,38 @@ Learn more info here:</source>
     </message>
     <message>
         <source>is valid</source>
-        <translation>действует</translation>
+		<comment>Signature</comment>
+        <translation>действительна</translation>
+    </message>
+    <message>
+        <source>is valid</source>
+		<comment>Timestamp</comment>
+        <translation>действителен</translation>
     </message>
     <message>
         <source>is not valid</source>
-        <translation>не действует</translation>
+		<comment>Signature</comment>
+        <translation>недействительна</translation>
+    </message>
+    <message>
+        <source>is not valid</source>
+		<comment>Timestamp</comment>
+        <translation>недействителен</translation>
     </message>
     <message>
         <source>is unknown</source>
-        <translation>неизвестно</translation>
+		<comment>Signature</comment>
+        <translation>неизвестная</translation>
+    </message>
+    <message>
+        <source>is unknown</source>
+		<comment>Timestamp</comment>
+        <translation>неизвестный</translation>
     </message>
     <message numerus="yes">
         <source>%n signatures are not valid</source>
         <translation>
-            <numerusform>%n подпись не действует</numerusform>
+            <numerusform>%n подпись недействительна</numerusform>
             <numerusform>%n подписи недействительны</numerusform>
             <numerusform>%n подписи недействительны</numerusform>
         </translation>
@@ -781,7 +799,7 @@ Learn more info here:</source>
     <message numerus="yes">
         <source>%n timestamps are not valid</source>
         <translation>
-            <numerusform>%n временной штамп не действует</numerusform>
+            <numerusform>%n временной штамп недействителен</numerusform>
             <numerusform>%n временных штампов недействительны</numerusform>
             <numerusform>%n временных штампов недействительны</numerusform>
         </translation>
@@ -940,7 +958,7 @@ Learn more info here:</source>
     </message>
     <message>
         <source>Valid:</source>
-        <translation>Действительный:</translation>
+        <translation>Действителен:</translation>
     </message>
     <message>
         <source>From</source>
@@ -1947,7 +1965,13 @@ Additional licenses and components</source>
     </message>
     <message>
         <source>is valid</source>
-        <translation>действует</translation>
+		<comment>Signature</comment>
+        <translation>действительна</translation>
+    </message>
+    <message>
+        <source>is valid</source>
+		<comment>Timestamp</comment>
+        <translation>действителен</translation>
     </message>
     <message>
         <source>Warnings</source>
@@ -1971,7 +1995,13 @@ Additional licenses and components</source>
     </message>
     <message>
         <source>is unknown</source>
-        <translation>неизвестно</translation>
+		<comment>Signature</comment>
+        <translation>неизвестная</translation>
+    </message>
+    <message>
+        <source>is unknown</source>
+		<comment>Timestamp</comment>
+        <translation>неизвестный</translation>
     </message>
     <message>
         <source>Unknown error</source>
@@ -1979,7 +2009,13 @@ Additional licenses and components</source>
     </message>
     <message>
         <source>is not valid</source>
+		<comment>Signature</comment>
         <translation>недействительна</translation>
+    </message>
+    <message>
+        <source>is not valid</source>
+		<comment>Timestamp</comment>
+        <translation>недействителен</translation>
     </message>
     <message>
         <source>Test signature is signed with test certificates that are similar to the certificates of real tokens, but digital signatures with legal force cannot be given with them as there is no actual owner of the card. &lt;a href='http://www.id.ee/index.php?id=30494'&gt;Additional information&lt;/a&gt;.</source>

--- a/client/translations/ru.ts
+++ b/client/translations/ru.ts
@@ -901,8 +901,8 @@ Learn more info here:</source>
         <translation>ИЗМЕНИТЬ PUK</translation>
     </message>
     <message>
-        <source>%1PUK code is blocked because the PUK code has been entered 3 times incorrectly. Unable to disable the PUK code itself. %2 As long as the PUK code is blocked, all eID options can be used, except PUK code. %2You can only use the new PUK code with the new code envelope that you can use%3 from PPA%4.</source>
-        <translation>%1PUK заблокирован, потому что PUK введен неверно 3 раза. PUK невозможно разблокировать самому. %2 Пока PUK код заблокирован, можно использовать все возможности eID, кроме тех которые требуют PUK. %2 Новый PUK получите в конверте с кодами %3 из PPA%4.</translation>
+        <source>PUK code is blocked because the PUK code has been entered 3 times incorrectly. Unable to disable the PUK code itself. As long as the PUK code is blocked, all eID options can be used, except PUK code. You can only use the new PUK code with the new code envelope that you can use from PPA.</source>
+        <translation>PUK заблокирован, потому что PUK введен неверно 3 раза. PUK невозможно разблокировать самому. &lt;br&gt;&lt;br&gt;Пока PUK код заблокирован, можно использовать все возможности eID, кроме тех которые требуют PUK. &lt;br&gt;&lt;br&gt;Новый PUK получите в конверте с кодами &lt;a href=&quot;https://www.politsei.ee/ru/nouanded/id-kaart-ja-pass/kui-id-kaardi-koodid-kaovad.dot&quot;&gt;из PPA&lt;/a&gt;.</translation>
     </message>
 </context>
 
@@ -2355,8 +2355,8 @@ Additional licenses and components</source>
         <translation>ВПЕРЕД</translation>
     </message>
     <message>
-        <source>Your ID-card certificates cannot be renewed starting from 01.07.2017. Your document is still valid until its expiring date and it can be used to login to e-services and give digital signatures. If there are problems using Your ID-card in e-services please contact ID-card helpdesk by phone (+372) 677 3377 or visit Police and Border Guard Board service point.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;http://id.ee/?id=30519&amp;read=38011&quot;&gt;More info&lt;/a&gt;</source>
-        <translation>Сертификаты вашей ID-карты не могут быть продлены с 01.07.2017. Ваш документ по-прежнему действует до истечения срока его действия, и его можно использовать для входа в электронные службы и предоставления цифровых подписей. Если у вас есть проблемы с использованием вашей ID-карты в электронных сервисах, обратитесь в службу поддержки ID-карт по телефону (+372) 677 3377 или посетите пункт обслуживания полиции и пограничной охраны.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;http://id.ee/?id=30519&amp;read=38011&quot;&gt;Больше информации&lt;/a&gt;</translation>
+        <source>Your ID-card certificates cannot be renewed starting from 01.07.2017.</source>
+        <translation>С 01.07.2017 обновление сертификатов на этой карте больше невозможно. Документ действителен до истечения срока его действия, и его можно использовать для авторизации в дигитальных сервисах и создания дигитальной подписи. Если возникнут проблемы с использованием карты в дигитальных сервисах, обратитесь в службу поддержки ID-карты по телефону (+372) 677 3377 или посетите один из пунктов обслуживания Департамента полиции и пограничной охраны.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;http://id.ee/?id=30625&amp;read=38012&quot;&gt;Дополнительная информация&lt;/a&gt;</translation>
     </message>
     <message>
         <source>Certificate is not registered in the certificate store. Register now?</source>

--- a/client/widgets/ContainerPage.cpp
+++ b/client/widgets/ContainerPage.cpp
@@ -275,7 +275,7 @@ void ContainerPage::changeEvent(QEvent* event)
 
 void ContainerPage::setHeader(const QString &file)
 {
-	fileName = file;
+	fileName = QDir::toNativeSeparators (file);
 	containerFileWidth = fm.width(fileName);
 	elideFileName(true);
 }

--- a/client/widgets/FileList.cpp
+++ b/client/widgets/FileList.cpp
@@ -135,11 +135,11 @@ void FileList::saveAll()
 					continue;
 			}
 			WarningDialog dlg(tr("%1 already exists.<br />Do you want replace it?").arg( dest ), qApp->activeWindow());
-			dlg.setButtonSize(100, 5);
-			dlg.setCancelText(tr("CANCEL"));
+			dlg.setButtonSize(60, 5);
+			dlg.setCancelText(tr("NO"));
 			dlg.addButton(tr("YES"), QMessageBox::Yes);
-			dlg.addButton(tr("NO"), QMessageBox::No);
-			dlg.addButton(tr("YES TO ALL"), QMessageBox::YesToAll);
+			dlg.addButton(tr("SAVE WITH OTHER NAME"), QMessageBox::No);
+			dlg.addButton(tr("REPLACE ALL"), QMessageBox::YesToAll);
 			b = dlg.exec();
 
 			if( b == QMessageBox::Cancel )

--- a/client/widgets/SignatureItem.cpp
+++ b/client/widgets/SignatureItem.cpp
@@ -108,20 +108,20 @@ void SignatureItem::init()
 	switch( signatureValidity )
 	{
 	case DigiDocSignature::Valid:
-		sa << tr("is valid");
-		sc << "<font color=\"green\">" << label << " " << tr("is valid") << "</font>";
+		sa << tr("is valid", isSignature ? "Signature" : "Timestamp");
+		sc << "<font color=\"green\">" << label << " " << tr("is valid", isSignature ? "Signature" : "Timestamp") << "</font>";
 		break;
 	case DigiDocSignature::Warning:
-		sa << tr("is valid") << " (" << tr("Warnings") << ")";
-		sc << "<font color=\"green\">" << label << " " << tr("is valid") << "</font> <font color=\"gold\">(" << tr("Warnings") << ")";
+		sa << tr("is valid", isSignature ? "Signature" : "Timestamp") << " (" << tr("Warnings") << ")";
+		sc << "<font color=\"green\">" << label << " " << tr("is valid", isSignature ? "Signature" : "Timestamp") << "</font> <font color=\"gold\">(" << tr("Warnings") << ")";
 		break;
 	case DigiDocSignature::NonQSCD:
-		sa << tr("is valid") << " (" << tr("Restrictions") << ")";
-		sc << "<font color=\"green\">" << label << " " << tr("is valid") << "</font> <font color=\"gold\">(" << tr("Restrictions") << ")";
+		sa << tr("is valid", isSignature ? "Signature" : "Timestamp") << " (" << tr("Restrictions") << ")";
+		sc << "<font color=\"green\">" << label << " " << tr("is valid", isSignature ? "Signature" : "Timestamp") << "</font> <font color=\"gold\">(" << tr("Restrictions") << ")";
 		break;
 	case DigiDocSignature::Test:
-		sa << tr("is valid") << " (" << tr("Test signature") << ")";
-		sc << "<font color=\"green\">" << label << " " << tr("is valid") << "</font> <font>(" << tr("Test signature") << ")";
+		sa << tr("is valid", isSignature ? "Signature" : "Timestamp") << " (" << tr("Test signature") << ")";
+		sc << "<font color=\"green\">" << label << " " << tr("is valid", isSignature ? "Signature" : "Timestamp") << "</font> <font>(" << tr("Test signature") << ")";
 		break;
 	case DigiDocSignature::Invalid:
 		if(isSignature)
@@ -129,8 +129,8 @@ void SignatureItem::init()
 		else
 			error = "%n timestamps are not valid";
 		link = "https://www.id.ee/index.php?id=30591";
-		sa << tr("is not valid");
-		sc << "<font color=\"red\">" << label << " " << tr("is not valid");
+		sa << tr("is not valid", isSignature ? "Signature" : "Timestamp");
+		sc << "<font color=\"red\">" << label << " " << tr("is not valid", isSignature ? "Signature" : "Timestamp");
 		break;
 	case DigiDocSignature::Unknown:
 		if(isSignature)
@@ -138,8 +138,8 @@ void SignatureItem::init()
 		else
 			error = "%n timestamps are unknown";
 		link = "http://id.ee/?lang=en&id=34317";
-		sa << tr("is unknown");
-		sc << "<font color=\"red\">" << label << " " << tr("is unknown");
+		sa << tr("is unknown", isSignature ? "Signature" : "Timestamp");
+		sc << "<font color=\"red\">" << label << " " << tr("is unknown", isSignature ? "Signature" : "Timestamp");
 		break;
 	}
 	sc << "</span>";

--- a/client/widgets/VerifyCert.cpp
+++ b/client/widgets/VerifyCert.cpp
@@ -158,11 +158,7 @@ void VerifyCert::update(bool showWarning)
 		txt = tr("The PUK code is located in your envelope");
 		changeBtn = tr("CHANGE PUK");
 		error = ( isBlockedPin ) ?
-			tr("%1PUK code is blocked because the PUK code has been entered 3 times incorrectly. Unable to disable the PUK code itself. %2 As long as the PUK code is blocked, all eID options can be used, except PUK code. %2You can only use the new PUK code with the new code envelope that you can use%3 from PPA%4.")
-					.arg("<span>")
-					.arg("<br><br>")
-					.arg("<u>")
-					.arg("</u></span>")
+			tr("PUK code is blocked because the PUK code has been entered 3 times incorrectly. Unable to disable the PUK code itself. As long as the PUK code is blocked, all eID options can be used, except PUK code. You can only use the new PUK code with the new code envelope that you can use from PPA.")
 			: "";
 		ui->changePIN->setDisabled(cardData.version() == QSmartCardData::VER_USABLEUPDATER);
 		break;

--- a/client/widgets/VerifyCert.ui
+++ b/client/widgets/VerifyCert.ui
@@ -241,6 +241,12 @@ background-color: #F8DDA7;
         <property name="wordWrap">
          <bool>true</bool>
         </property>
+        <property name="openExternalLinks">
+         <bool>true</bool>
+        </property>
+        <property name="textInteractionFlags">
+         <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse</set>
+        </property>
        </widget>
       </item>
       <item>


### PR DESCRIPTION
   DDKLIEN-69 texts are taken from old digidoc utility.
   Fix translation reference of 'Certificates have expired!'.
   Fixed DDKLIEN-71
   Fixed DDKLIEN-47
   Fixed DDKLIEN-72
   Fixed DDKLIEN-73
   Add support for Russian text declension rules 

Signed-off-by: Oleg Prokofjev oleg@aktors.ee