### PR TITLE
Fix dialog sizes to fit the text (Windows issue)

### DIFF
--- a/client/dialogs/FirstRun.ui
+++ b/client/dialogs/FirstRun.ui
@@ -312,7 +312,7 @@ text-align: center;</string>
      <property name="geometry">
       <rect>
        <x>30</x>
-       <y>418</y>
+       <y>460</y>
        <width>298</width>
        <height>34</height>
       </rect>
@@ -361,7 +361,7 @@ QPushButton:disabled {
      <property name="geometry">
       <rect>
        <x>363</x>
-       <y>418</y>
+       <y>460</y>
        <width>298</width>
        <height>34</height>
       </rect>
@@ -407,7 +407,7 @@ QPushButton:disabled {
      <property name="geometry">
       <rect>
        <x>696</x>
-       <y>418</y>
+       <y>460</y>
        <width>298</width>
        <height>34</height>
       </rect>
@@ -572,7 +572,7 @@ color: #041E42;</string>
        <x>30</x>
        <y>340</y>
        <width>298</width>
-       <height>72</height>
+       <height>120</height>
       </rect>
      </property>
      <property name="font">
@@ -602,7 +602,7 @@ line-height: 16px;</string>
        <x>363</x>
        <y>340</y>
        <width>298</width>
-       <height>72</height>
+       <height>120</height>
       </rect>
      </property>
      <property name="font">
@@ -632,7 +632,7 @@ line-height: 16px;</string>
        <x>696</x>
        <y>340</y>
        <width>298</width>
-       <height>72</height>
+       <height>120</height>
       </rect>
      </property>
      <property name="font">
@@ -829,7 +829,7 @@ border-radius: 3px;</string>
      <property name="geometry">
       <rect>
        <x>363</x>
-       <y>481</y>
+       <y>500</y>
        <width>298</width>
        <height>34</height>
       </rect>
@@ -875,7 +875,7 @@ QPushButton:disabled {
      <property name="geometry">
       <rect>
        <x>436</x>
-       <y>525</y>
+       <y>540</y>
        <width>151</width>
        <height>25</height>
       </rect>
@@ -929,7 +929,7 @@ QPushButton:disabled {
      <property name="geometry">
       <rect>
        <x>490</x>
-       <y>558</y>
+       <y>573</y>
        <width>15</width>
        <height>15</height>
       </rect>
@@ -961,7 +961,7 @@ image: url(:/images/icon_dot_active.png);</string>
      <property name="geometry">
       <rect>
        <x>520</x>
-       <y>558</y>
+       <y>573</y>
        <width>15</width>
        <height>15</height>
       </rect>
@@ -993,7 +993,7 @@ image: url(:/images/icon_dot.png);</string>
      <property name="geometry">
       <rect>
        <x>505</x>
-       <y>558</y>
+       <y>573</y>
        <width>15</width>
        <height>15</height>
       </rect>
@@ -1112,7 +1112,7 @@ color: #041E42;</string>
        <x>30</x>
        <y>386</y>
        <width>298</width>
-       <height>88</height>
+       <height>150</height>
       </rect>
      </property>
      <property name="font">
@@ -1142,7 +1142,7 @@ line-height: 16px;</string>
        <x>363</x>
        <y>386</y>
        <width>298</width>
-       <height>88</height>
+       <height>110</height>
       </rect>
      </property>
      <property name="font">
@@ -1195,7 +1195,7 @@ color: #041E42;</string>
        <x>696</x>
        <y>386</y>
        <width>298</width>
-       <height>88</height>
+       <height>150</height>
       </rect>
      </property>
      <property name="font">
@@ -1228,7 +1228,7 @@ line-height: 16px;</string>
      <property name="geometry">
       <rect>
        <x>490</x>
-       <y>558</y>
+       <y>573</y>
        <width>15</width>
        <height>15</height>
       </rect>
@@ -1260,7 +1260,7 @@ image: url(:/images/icon_dot.png);</string>
      <property name="geometry">
       <rect>
        <x>520</x>
-       <y>558</y>
+       <y>573</y>
        <width>15</width>
        <height>15</height>
       </rect>
@@ -1292,7 +1292,7 @@ image: url(:/images/icon_dot.png);</string>
      <property name="geometry">
       <rect>
        <x>505</x>
-       <y>558</y>
+       <y>573</y>
        <width>15</width>
        <height>15</height>
       </rect>
@@ -1411,7 +1411,7 @@ color: #041E42;</string>
        <x>30</x>
        <y>386</y>
        <width>298</width>
-       <height>104</height>
+       <height>160</height>
       </rect>
      </property>
      <property name="font">
@@ -1441,7 +1441,7 @@ line-height: 16px;</string>
        <x>363</x>
        <y>386</y>
        <width>298</width>
-       <height>88</height>
+       <height>110</height>
       </rect>
      </property>
      <property name="font">
@@ -1494,7 +1494,7 @@ color: #041E42;</string>
        <x>696</x>
        <y>386</y>
        <width>298</width>
-       <height>88</height>
+       <height>140</height>
       </rect>
      </property>
      <property name="font">
@@ -1522,7 +1522,7 @@ line-height: 16px;</string>
      <property name="geometry">
       <rect>
        <x>436</x>
-       <y>525</y>
+       <y>540</y>
        <width>151</width>
        <height>25</height>
       </rect>
@@ -1576,7 +1576,7 @@ QPushButton:disabled {
      <property name="geometry">
       <rect>
        <x>363</x>
-       <y>481</y>
+       <y>500</y>
        <width>298</width>
        <height>34</height>
       </rect>
@@ -1696,7 +1696,7 @@ border-radius: 3px;</string>
      <property name="geometry">
       <rect>
        <x>490</x>
-       <y>558</y>
+       <y>570</y>
        <width>15</width>
        <height>15</height>
       </rect>
@@ -1728,7 +1728,7 @@ image: url(:/images/icon_dot.png);</string>
      <property name="geometry">
       <rect>
        <x>505</x>
-       <y>558</y>
+       <y>570</y>
        <width>15</width>
        <height>15</height>
       </rect>
@@ -1760,7 +1760,7 @@ image: url(:/images/icon_dot.png);</string>
      <property name="geometry">
       <rect>
        <x>520</x>
-       <y>558</y>
+       <y>570</y>
        <width>15</width>
        <height>15</height>
       </rect>
@@ -1863,7 +1863,7 @@ color: #041E42;</string>
        <x>30</x>
        <y>386</y>
        <width>298</width>
-       <height>88</height>
+       <height>150</height>
       </rect>
      </property>
      <property name="font">
@@ -1893,7 +1893,7 @@ line-height: 16px;</string>
        <x>363</x>
        <y>386</y>
        <width>298</width>
-       <height>88</height>
+       <height>110</height>
       </rect>
      </property>
      <property name="font">
@@ -1923,7 +1923,7 @@ line-height: 16px;</string>
        <x>696</x>
        <y>386</y>
        <width>298</width>
-       <height>88</height>
+       <height>140</height>
       </rect>
      </property>
      <property name="font">
@@ -1951,7 +1951,7 @@ line-height: 16px;</string>
      <property name="geometry">
       <rect>
        <x>363</x>
-       <y>481</y>
+       <y>500</y>
        <width>298</width>
        <height>34</height>
       </rect>

--- a/client/dialogs/SettingsDialog.cpp
+++ b/client/dialogs/SettingsDialog.cpp
@@ -453,6 +453,7 @@ void SettingsDialog::updateCert()
 		ui->txtAccessCert->setText( 
 			tr("FREE_CERT_EXCEEDED") + "<br /><br />" +
 			"<b>" + tr("Server access certificate is not installed.") + "</b>" );
+	ui->txtAccessCert->adjustSize();
 	ui->btnNavShowCertificate->setEnabled( !c.isNull() );
 	ui->btnNavShowCertificate->setProperty( "cert", QVariant::fromValue( c ) );
 }

--- a/client/dialogs/SettingsDialog.ui
+++ b/client/dialogs/SettingsDialog.ui
@@ -1019,19 +1019,19 @@ QRadioButton::indicator::checked {
             <x>21</x>
             <y>130</y>
             <width>749</width>
-            <height>60</height>
+            <height>70</height>
            </rect>
           </property>
           <property name="minimumSize">
            <size>
             <width>749</width>
-            <height>60</height>
+            <height>70</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
             <width>749</width>
-            <height>60</height>
+            <height>70</height>
            </size>
           </property>
           <property name="text">
@@ -1367,7 +1367,7 @@ background-color: #FFFFFF;
           <property name="maximumSize">
            <size>
             <width>749</width>
-            <height>120</height>
+            <height>130</height>
            </size>
           </property>
           <property name="text">
@@ -1393,7 +1393,7 @@ background-color: #FFFFFF;
           <property name="geometry">
            <rect>
             <x>21</x>
-            <y>150</y>
+            <y>160</y>
             <width>700</width>
             <height>16</height>
            </rect>

--- a/client/translations/en.ts
+++ b/client/translations/en.ts
@@ -1685,10 +1685,8 @@ new codes.&lt;/li&gt;
         <translation>Default file type</translation>
     </message>
     <message>
-        <source>ASiC-E – international digital signature format that will be used across European countries
-</source>
-        <translation>ASiC-E – international digital signature format that will be used across European countries
-</translation>
+        <source>ASiC-E – international digital signature format that will be used across European countries</source>
+        <translation>ASiC-E – international digital signature format that will be used across European countries.</translation>
     </message>
     <message>
         <source>BDOC – default digital signature format in Estonia.</source>

--- a/client/translations/et.ts
+++ b/client/translations/et.ts
@@ -1688,12 +1688,12 @@ saada on pöörduda &lt;u&gt;klienditeeninduspunkti&lt;/u&gt; poole.&lt;/li&gt;
     <message>
         <source>ASiC-E – international digital signature format that will be used across European countries
 </source>
-        <translation>ASiC-E - rahvusvahelisele, Euroopa-ülesele ühilduvusele suunatud tulevikuvorming
+        <translation>ASiC-E - rahvusvahelisele, Euroopa-ülesele ühilduvusele suunatud tulevikuvorming.
 </translation>
     </message>
     <message>
         <source>BDOC – default digital signature format in Estonia.</source>
-        <translation>BDOC - digiallkirja vaikimisi vorming Eestis</translation>
+        <translation>BDOC - digiallkirja vaikimisi vorming Eestis.</translation>
     </message>
     <message>
         <source>If you want to change the digital signature format then it should be done before adding signable files to the container. Otherwise the document will be created in the previous default format. When adding signatures, it is no longer possible to change the format of the document.</source>

--- a/client/translations/ru.ts
+++ b/client/translations/ru.ts
@@ -1686,7 +1686,7 @@ ID-карты, это обратиться в &lt;u&gt;бюро обслужив
     </message>
     <message>
         <source>Select the default directory</source>
-        <translation>Выберите каталог по умолчанию</translation>
+        <translation>Выберите каталог</translation>
     </message>
     <message>
         <source>Default file type</source>
@@ -1696,7 +1696,7 @@ ID-карты, это обратиться в &lt;u&gt;бюро обслужив
         <source>ASiC-E – international digital signature format that will be used across European countries
 </source>
         <translation>ASiC-E – это разрабатываемый международный формат цифровой подписи, который будет
-использоваться в европейских государствах</translation>
+использоваться в европейских государствах.</translation>
     </message>
     <message>
         <source>BDOC – default digital signature format in Estonia.</source>

--- a/client/widgets/ContainerPage.ui
+++ b/client/widgets/ContainerPage.ui
@@ -115,7 +115,7 @@ background-color: #F4F5F6;
         </property>
         <property name="maximumSize">
          <size>
-          <width>74</width>
+          <width>77</width>
           <height>16777215</height>
          </size>
         </property>


### PR DESCRIPTION
   1. First Run labels are increased so that text would fit (problem in
   Windows)
   2. Settings dialog labels' sizes are increased as well ( Windows
   problem).
   3. 'Container:' text in Russian lang. did not fit in Windows (fixed).

Signed-off-by: Oleg Prokofjev oleg@aktors.ee