### PR TITLE
Use common lock for QSigner and QSmartCard

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -49,6 +49,7 @@ add_executable( ${PROGNAME} WIN32 MACOSX_BUNDLE
 	FileDialog.cpp
 	MainWindow.cpp
 	MainWindow_MyEID.cpp
+	QCardLock.cpp
 	QPKCS11.cpp
 	QSigner.cpp
 	QSmartCard.cpp

--- a/client/MainWindow_MyEID.cpp
+++ b/client/MainWindow_MyEID.cpp
@@ -20,9 +20,9 @@
 #include "MainWindow.h"
 #include "ui_MainWindow.h"
 #include "Application.h"
+#include "QCardLock.h"
 #include "QSigner.h"
 #include "XmlReader.h"
-#include "QSmartCard_p.h"
 #ifdef Q_OS_WIN
 	#include "CertStore.h"
 #endif
@@ -340,9 +340,10 @@ void MainWindow::updateCertificate()
 			s.remove(c);
 	}
 #endif
-	qApp->smartcard()->d->m.lock();
-	Updater(qApp->smartcard()->data().reader(), this).execute();
-	qApp->smartcard()->d->m.unlock();
+	{
+		QCardLocker locker;
+		Updater(qApp->smartcard()->data().reader(), this).execute();
+	}
 	qApp->smartcard()->reload();
 }
 

--- a/client/QCardLock.cpp
+++ b/client/QCardLock.cpp
@@ -1,0 +1,79 @@
+/*
+ * QDigiDoc4
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include "QCardLock.h"
+#include "QCardLock_p.h"
+
+
+QCardLockPrivate::QCardLockPrivate()
+: readLock(QMutex::Recursive)
+, exclusiveLock(QMutex::NonRecursive)
+{}
+
+QCardLock::QCardLock()
+: d(new QCardLockPrivate)
+{
+}
+
+QCardLock::~QCardLock()
+{
+	delete d;
+}
+
+void QCardLock::exclusiveLock()
+{
+	readLock();
+	d->exclusiveLock.lock();
+}
+
+bool QCardLock::exclusiveTryLock()
+{
+	readLock();
+	bool rc = d->exclusiveLock.tryLock();
+	if(!rc)
+		readUnlock();
+	return rc;
+}
+
+void QCardLock::exclusiveUnlock()
+{
+	d->exclusiveLock.unlock();
+	readUnlock();
+}
+
+QCardLock& QCardLock::instance()
+{
+	static QCardLock lock;
+	return lock;
+}
+
+void QCardLock::readLock()
+{
+	d->readLock.lock();
+}
+
+bool QCardLock::readTryLock()
+{
+	return d->readLock.tryLock();
+}
+
+void QCardLock::readUnlock()
+{
+	d->readLock.unlock();
+}

--- a/client/QCardLock.h
+++ b/client/QCardLock.h
@@ -1,0 +1,59 @@
+/*
+ * QDigiDoc4
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#pragma once
+
+#include <QObject>
+
+class QCardLockPrivate;
+
+class QCardLock
+{
+public:
+	~QCardLock();
+	static QCardLock& instance();
+
+	void exclusiveLock();
+	bool exclusiveTryLock();
+	void exclusiveUnlock();
+	void readLock();
+	bool readTryLock();
+	void readUnlock();
+
+private:
+	QCardLock();
+	Q_DISABLE_COPY(QCardLock);
+	QCardLockPrivate *d;
+};
+
+class QCardLocker
+{
+public:
+	inline QCardLocker()
+	{ 
+		QCardLock::instance().exclusiveLock();
+	}
+	inline ~QCardLocker()
+	{
+		QCardLock::instance().exclusiveUnlock();
+	}
+
+private:
+	Q_DISABLE_COPY(QCardLocker)
+};

--- a/client/QCardLock_p.h
+++ b/client/QCardLock_p.h
@@ -1,0 +1,31 @@
+/*
+ * QDigiDoc4
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#pragma once
+
+#include <QMutex>
+
+class QCardLockPrivate
+{
+public:
+	explicit QCardLockPrivate();
+
+	QMutex readLock;
+	QMutex exclusiveLock;
+};

--- a/client/QSmartCard_p.h
+++ b/client/QSmartCard_p.h
@@ -22,7 +22,6 @@
 #include <common/QPCSC.h>
 #include <common/SslCertificate.h>
 
-#include <QtCore/QMutex>
 #include <QtCore/QStringList>
 #include <QtCore/QTextCodec>
 #include <QtCore/QVariant>
@@ -48,7 +47,6 @@ public:
 		const BIGNUM *inv, const BIGNUM *rp, EC_KEY *eckey);
 
 	QSharedPointer<QPCSCReader> reader;
-	QMutex			m;
 	QSmartCardData	t;
 	QMap<QString, QSharedPointer<QCardInfo>> cache;
 	volatile bool	terminate = false;


### PR DESCRIPTION
- Common locking (QCardLock) used for polling / signing / decrypting
  in QSigner and polling / card operations in QSmartCard

Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>