### PR TITLE
UBUNTU wrong pin2 on signing opens new client window

### DIFF
--- a/client/QPKCS11.cpp
+++ b/client/QPKCS11.cpp
@@ -41,7 +41,16 @@ QWidget* rootWindow()
 	QWidget* win = qApp->activeWindow();
 	QWidget* root = nullptr;
 
-	while(win)
+    if (!win)
+        for (QWidget *widget: qApp->topLevelWidgets()) {
+            if (widget->isWindow())
+            {
+                win = widget;
+                break;
+            }
+        }
+
+    while(win)
 	{
 		root = win;
 		win = win->parentWidget();


### PR DESCRIPTION
   When user enters a wrong PIN2 on document signing in UBUNTU then new
   (not needed) qdigidoc4 window is shown. It is fixed.
   DDKLIEN-53 - works OK. No crash.

Signed-off-by: Oleg Prokofjev oleg@aktors.ee