### PR TITLE
Fix #163 - name for `qdigidoc4` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Client is actively developed and is currently in alpha-stage.
 
 6. Execute
 
-        /usr/local/bin/qdigidocclient
+        /usr/local/bin/qdigidoc4
 
 ### macOS
 


### PR DESCRIPTION
Fix fixes #163 by fixing README.md, but there are still mentions of the old name https://github.com/open-eid/DigiDoc4-Client/search?utf8=%E2%9C%93&q=qdigidocclient&type=