### PR TITLE
Context-sensitive opening of files

### DIFF
--- a/client/dialogs/CertificateHistory.cpp
+++ b/client/dialogs/CertificateHistory.cpp
@@ -25,7 +25,6 @@
 #include "dialogs/CertificateDetails.h"
 #include "effects/Overlay.h"
 
-#include <QDebug>
 #include <QFile>
 #include <QMessageBox>
 #include <QStandardPaths>

--- a/client/widgets/WarningItem.cpp
+++ b/client/widgets/WarningItem.cpp
@@ -27,24 +27,24 @@
 
 WarningText::WarningText(const QString &text, const QString &details, int page)
 : text(text)
-, details(details)
 , counter(0)
+, details(details)
 , external(false)
 , page(page)
 , warningType(ria::qdigidoc4::NoWarning)
 {}
 
 WarningText::WarningText(ria::qdigidoc4::WarningType warningType)
-: external(false)
-, counter(0)
+: counter(0)
+, external(false)
 , page(-1)
 , warningType(warningType)
 {
 }
 
 WarningText::WarningText(ria::qdigidoc4::WarningType warningType, int counter)
-: external(true)
-, counter(counter)
+: counter(counter)
+, external(true)
 , page(ria::qdigidoc4::SignDetails)
 , warningType(warningType)
 {


### PR DESCRIPTION
DDKLIEN-59 - Open files based on the page currently opened:
- If on crypto-page, all files are opened as cryptocontainers: either
   new one is created (even in case of asic/pdf/bdoc) or
   existing cdoc is opened
- If on signature page, all files are opened as signature containers:
   either new one is created (even in case of cdoc) or
   existing asic/pdf/bdoc is opened
- If on myEid page, either new signature container is created or
   existing signature or crypto-container is opened

Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>