### PR TITLE
Pin blocked issues

### DIFF
--- a/client/Application.cpp
+++ b/client/Application.cpp
@@ -704,6 +704,18 @@ QWidget* Application::mainWindow()
 	QWidget* win = activeWindow();
 	QWidget* root = nullptr;
 
+	if (!win)
+	{	// Happens on Ubuntu only.
+		for (QWidget *widget: qApp->topLevelWidgets())
+		{
+			if (widget->isWindow())
+			{
+				win = widget;
+				break;
+			}
+		}
+	}
+
 	while(win)
 	{
 		root = win;

--- a/client/MainWindow.cpp
+++ b/client/MainWindow.cpp
@@ -663,9 +663,9 @@ void MainWindow::onCryptoAction(int action, const QString &id, const QString &ph
 			FadeInNotification* notification = new FadeInNotification( this, WHITE, MANTIS, 110 );
 			notification->start( tr("Decryption succeeded"), 750, 3000, 1200 );
 		}
-		else if((qApp->signer()->tokensign().flags() & TokenData::PinLocked))
+		else if((qApp->signer()->tokenauth().flags() & TokenData::PinLocked))
 		{
-			qApp->smartcard()->reload(); // QSmartCard should also know that PIN is blocked.
+			qApp->smartcard()->reload(); // QSmartCard should also know that PIN1 is blocked.
 			showPinBlockedWarning(qApp->smartcard()->data());
 		}
 		break;

--- a/client/MainWindow_MyEID.cpp
+++ b/client/MainWindow_MyEID.cpp
@@ -114,7 +114,7 @@ void MainWindow::pinUnblock( QSmartCardData::PinType type, bool isForgotPin )
 		if (type == QSmartCardData::Pin2Type)
 		{
 			clearWarning(WarningType::UnblockPin2Warning);
-			emit ui->cryptoContainerPage->cardChanged(card);
+			emit ui->signContainerPage->cardChanged(card);
 		}
 	}
 }

--- a/client/QSigner.cpp
+++ b/client/QSigner.cpp
@@ -186,6 +186,8 @@ QSigner::ErrorCode QSigner::decrypt(const QByteArray &in, QByteArray &out, const
 			// else pin locked, fall through
 		case QPKCS11::PinLocked:
 			QCardLock::instance().exclusiveUnlock();
+			if (status != QPKCS11::PinIncorrect)
+				reloadauth();
 			Q_EMIT error( QPKCS11::errorString( status ) );
 			return PinLocked;
 		default:
@@ -210,6 +212,7 @@ QSigner::ErrorCode QSigner::decrypt(const QByteArray &in, QByteArray &out, const
 		if(d->win->lastError() == QWin::PinCanceled)
 		{
 			QCardLock::instance().exclusiveUnlock();
+			smartcard()->reload(); // QSmartCard should also know that PIN1 is blocked.
 			return PinCanceled;
 		}
 	}
@@ -490,6 +493,7 @@ std::vector<unsigned char> QSigner::sign(const std::string &method, const std::v
 		if(d->win->lastError() == QWin::PinCanceled)
 		{
 			QCardLock::instance().exclusiveUnlock();
+			smartcard()->reload(); // QSmartCard should also know that PIN2 is blocked.
 			throwException(tr("Failed to login token"), Exception::PINCanceled, __LINE__);
 		}
 	}

--- a/client/dialogs/SettingsDialog.cpp
+++ b/client/dialogs/SettingsDialog.cpp
@@ -623,7 +623,6 @@ void SettingsDialog::updateDiagnostics()
 	Diagnostics *worker = new Diagnostics();
 	connect(worker, &Diagnostics::update, ui->txtDiagnostics, &QTextBrowser::insertHtml, Qt::QueuedConnection);
 	connect(worker, &Diagnostics::destroyed, this, [=]{
-		QCardLock::instance().exclusiveUnlock();
 		if(!appletVersion.isEmpty())
 		{
 			QString info;
@@ -636,7 +635,6 @@ void SettingsDialog::updateDiagnostics()
 		ui->txtDiagnostics->ensureCursorVisible() ;
 		QApplication::restoreOverrideCursor();
 	});
-	QCardLock::instance().exclusiveLock();
 	QThreadPool::globalInstance()->start( worker );
 	if(Settings(QSettings::SystemScope).value("disableSave", false).toBool())
 	{


### PR DESCRIPTION
   1. Quick language switch (by mouse) in Settings dialog hangs
   application.
   2. When user blocks the PIN2 on singing (or PIN1 on decrypting) then
      re-read the token's data and show the warning message.
  3. Show the warning dialog in center of digidoc client application
   (Ubuntu problem only).