### PR TITLE
Remove picture cashing, add files to signed cont.

### DIFF
--- a/client/MainWindow.cpp
+++ b/client/MainWindow.cpp
@@ -206,10 +206,7 @@ void MainWindow::pageSelected( PageIcon *const page )
 		if(digiDoc)
 		{
 			navigate = false;
-			selectPageIcon(ui->signature);
-			ui->startScreen->setCurrentIndex(SignDetails);
-			updateWarnings();
-			adjustDrops();
+			selectPage(SignDetails);
 		}
 	}
 	else if(toPage == CryptoIntro)
@@ -217,10 +214,7 @@ void MainWindow::pageSelected( PageIcon *const page )
 		if(cryptoDoc)
 		{
 			navigate = false;
-			selectPageIcon(ui->crypto);
-			ui->startScreen->setCurrentIndex(CryptoDetails);
-			updateWarnings();
-			adjustDrops();
+			selectPage(CryptoDetails);
 		}
 	}
 
@@ -529,12 +523,7 @@ void MainWindow::navigateToPage( Pages page, const QStringList &files, bool crea
 	}
 
 	if(navigate)
-	{
-		selectPageIcon( page < CryptoIntro ? ui->signature : (page == MyEid ? ui->myEid : ui->crypto));
-		ui->startScreen->setCurrentIndex(page);
-		updateWarnings();
-		adjustDrops();
-	}
+		selectPage(page);
 }
 
 void MainWindow::onSignAction(int action, const QString &info1, const QString &info2)
@@ -618,8 +607,7 @@ void MainWindow::convertToCDoc()
 	resetCryptoDoc(cryptoContainer.release());
 	resetDigiDoc(nullptr, false);
 	ui->cryptoContainerPage->transition(cryptoDoc, false);
-	selectPageIcon(ui->crypto);
-	ui->startScreen->setCurrentIndex(CryptoDetails);
+	selectPage(CryptoDetails);
 
 	FadeInNotification* notification = new FadeInNotification( this, WHITE, MANTIS, 110 );
 	notification->start( tr("Converted to crypto container!"), 750, 3000, 1200 );
@@ -746,6 +734,8 @@ void MainWindow::openFiles(const QStringList &files, bool addFile)
 					cryptoDoc->documentModel() : digiDoc->documentModel();
 				for(auto file: content)
 					model->addFile(file);
+				selectPage(page);
+				return;
 			}
 		}
 		else
@@ -932,6 +922,14 @@ QString MainWindow::selectFile( const QString &title, const QString &filename, b
 
 	auto hider = WaitDialog::hider();
 	return FileDialog::getSaveFileName( this, title, filename, exts.join(";;"), &active );
+}
+
+void MainWindow::selectPage(Pages page)
+{
+	selectPageIcon( page < CryptoIntro ? ui->signature : (page == MyEid ? ui->myEid : ui->crypto));
+	ui->startScreen->setCurrentIndex(page);
+	updateWarnings();
+	adjustDrops();
 }
 
 void MainWindow::selectPageIcon( PageIcon* page )
@@ -1456,8 +1454,7 @@ bool MainWindow::wrap(const QString& wrappedFile, bool enclose)
 	resetDigiDoc(signatureContainer.release());
 
 	ui->signContainerPage->transition(digiDoc);
-	selectPageIcon(ui->signature);
-	ui->startScreen->setCurrentIndex(SignDetails);
+	selectPage(SignDetails);
 
 	return true;
 }

--- a/client/MainWindow.h
+++ b/client/MainWindow.h
@@ -130,6 +130,7 @@ private:
 	void removeSignatureFile(int index);
 	bool save();
 	QString selectFile( const QString &title, const QString &filename, bool fixedExt );
+	void selectPage(ria::qdigidoc4::Pages page);
 	void selectPageIcon( PageIcon* page );
 	QByteArray sendRequest( SSLConnect::RequestType type, const QString &param = QString() );
 	void showCardMenu( bool show );

--- a/client/MainWindow.h
+++ b/client/MainWindow.h
@@ -91,7 +91,7 @@ protected:
 	void showEvent(QShowEvent *event) override;
 
 private:
-	void cachePicture( const QString &id, const QImage &image );
+	void adjustDrops();
 	void browseOnDisk(const QString &fileName);
 	bool checkExpiration();
 	void clearWarning(int warningType);

--- a/client/MainWindow_MyEID.cpp
+++ b/client/MainWindow_MyEID.cpp
@@ -190,16 +190,6 @@ void MainWindow::activateEmail ()
 
 QByteArray MainWindow::sendRequest( SSLConnect::RequestType type, const QString &param )
 {
-/*
-	switch( type )
-	{
-	case SSLConnect::ActivateEmails: showLoading(  tr("Activating email settings") ); break;
-	case SSLConnect::EmailInfo: showLoading( tr("Loading email settings") ); break;
-	case SSLConnect::MobileInfo: showLoading( tr("Requesting Mobiil-ID status") ); break;
-	case SSLConnect::PictureInfo: showLoading( tr("Loading picture") ); break;
-	default: showLoading( tr( "Loading data" ) ); break;
-	}
-*/
 	if( !validateCardError( QSmartCardData::Pin1Type, type, qApp->smartcard()->login( QSmartCardData::Pin1Type ) ) )
 		return QByteArray();
 

--- a/client/Styles.cpp
+++ b/client/Styles.cpp
@@ -169,22 +169,3 @@ QFont Styles::font( Styles::Font font, int size, QFont::Weight weight )
 	f.setWeight( weight );
 	return f;
 }
-
-void Styles::cachedPicture(const QString &id, std::vector<PictureInterface*> pictureWidgets)
-{
-	Settings settings;
-	QVariantList index = settings.value("imageIndex").toList();
-
-	if(index.contains(id))
-	{
-		QImage image = settings.value("imageCache").toMap().value(id).value<QImage>();
-		QPixmap pixmap = QPixmap::fromImage( image );
-		for(auto widget: pictureWidgets)
-			widget->showPicture(pixmap);
-	}
-	else
-	{
-		for(auto widget: pictureWidgets)
-			widget->clearPicture();
-	}
-}

--- a/client/Styles.h
+++ b/client/Styles.h
@@ -23,7 +23,6 @@
 
 #include <QtCore/QtGlobal>
 #include <QFont>
-#include <QPixmap>
 
 class PictureInterface
 {
@@ -47,7 +46,6 @@ public:
 
 	static QFont font( Font font, int size );
 	static QFont font( Font font, int size, QFont::Weight weight );
-	static void cachedPicture( const QString &id, std::vector<PictureInterface*> pictureWidgets );
 
 private:
 	explicit Styles();

--- a/client/Styles.h
+++ b/client/Styles.h
@@ -23,6 +23,7 @@
 
 #include <QtCore/QtGlobal>
 #include <QFont>
+#include <QPixmap>
 
 class PictureInterface
 {

--- a/client/translations/et.ts
+++ b/client/translations/et.ts
@@ -281,7 +281,7 @@ Tüüp: %3</translation>
     </message>
     <message>
         <source>This is an executable file! Executable files may contain viruses or other malicious code that could harm your computer. Are you sure you want to launch this file?</source>
-        <translation>See on käivitatav fail! Käivitatavad failid võivad sisaldada viirusi või muud pahatahtlikku koodi, mis võib kahjustada sinu arvutit. Kas oled kindel, et tahad seda faili käivitada?</translation>
+        <translation>See on käivitatav fail! Käivitatavad failid võivad sisaldada viirusi või muud pahatahtlikku koodi, mis võib kahjustada Sinu arvutit. Kas oled kindel, et tahad seda faili käivitada?</translation>
     </message>
     <message>
         <source>Cannot add the file to the envelope. File '%1' is already in container.</source>
@@ -657,7 +657,7 @@ Tüüp: %3</translation>
     <message>
         <source>You do not have other eIDs.
 Learn more info here:</source>
-        <translation>Teil ei ole teisi eID-sid.
+        <translation>Sul ei ole teisi eID-sid.
 Rohkem infot leiate siit:</translation>
     </message>
     <message>
@@ -772,7 +772,7 @@ Rohkem infot leiate siit:</translation>
     </message>
     <message>
         <source>Your @eesti.ee e-mail has been forwarded to </source>
-        <translation>Teie @eesti.ee posti aadressid on suunatud e-postile </translation>
+        <translation>Sinu @eesti.ee posti aadressid on suunatud e-postile </translation>
     </message>
 </context>
 
@@ -1909,7 +1909,7 @@ Täiendavad litsentsid ja komponendid</translation>
     </message>
     <message>
         <source>The document has already been signed by you.</source>
-        <translation>Dokument on sinu poolt juba allkirjastatud.</translation>
+        <translation>Dokument on Sinu poolt juba allkirjastatud.</translation>
     </message>
     <message>
         <source>CONTINUE SIGNING</source>
@@ -2018,7 +2018,7 @@ Täiendavad litsentsid ja komponendid</translation>
     </message>
     <message>
         <source>Signature status is displayed "unknown" if you don't have all validity confirmation service certificates and/or certificate authority certificates installed into your computer (&lt;a href='http://id.ee/?lang=en&amp;id=34317'&gt;additional information&lt;/a&gt;).</source>
-		<translation>Allkirja staatust kuvatakse &quot;teadmata&quot;, kui teie arvutisse pole lisatud kõiki kehtivuskinnituse teenuse sertifikaate ja/või nende kontrolliks vajalikke sertifikaate (&lt;a href=&apos;http://www.id.ee/?id=35939&apos;&gt;lisainformatsioon&lt;/a&gt;).</translation>
+		<translation>Allkirja staatust kuvatakse &quot;teadmata&quot;, kui Sinu arvutisse pole lisatud kõiki kehtivuskinnituse teenuse sertifikaate ja/või nende kontrolliks vajalikke sertifikaate (&lt;a href=&apos;http://www.id.ee/?id=35939&apos;&gt;lisainformatsioon&lt;/a&gt;).</translation>
     </message>
     <message>
         <source>Signer&apos;s Certificate issuer</source>
@@ -2378,7 +2378,7 @@ Täiendavad litsentsid ja komponendid</translation>
     </message>
     <message>
         <source>Your ID-card certificates cannot be renewed starting from 01.07.2017.</source>
-        <translation>Teie ID-kaardi sertifikaate ei ole võimalik alates 01.07.2017 uuendada. Dokument kehtib oma kehtivusaja lõpuni ning sellega saab endiselt e-teenustesse sisse logida ning digiallkirja anda. Kui e-teenuste kasutamisel tekib tõrkeid, helistage ID-kaardi infotelefonile numbril 1777 või pöörduge Politsei- ja Piirivalveameti teeninduspunkti.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;http://id.ee/?id=30007&amp;read=38010&quot;&gt;Lisainfo&lt;/a&gt;</translation>
+        <translation>Sinu ID-kaardi sertifikaate ei ole võimalik alates 01.07.2017 uuendada. Dokument kehtib oma kehtivusaja lõpuni ning sellega saab endiselt e-teenustesse sisse logida ning digiallkirja anda. Kui e-teenuste kasutamisel tekib tõrkeid, helistage ID-kaardi infotelefonile numbril 1777 või pöörduge Politsei- ja Piirivalveameti teeninduspunkti.&lt;br /&gt;&lt;br /&gt;&lt;a href=&quot;http://id.ee/?id=30007&amp;read=38010&quot;&gt;Lisainfo&lt;/a&gt;</translation>
     </message>
     <message>
         <source>Certificate is not registered in the certificate store. Register now?</source>
@@ -2438,7 +2438,7 @@ Täiendavad litsentsid ja komponendid</translation>
     </message>
     <message>
         <source>This container is signed by you</source>
-        <translation>See ümbrik on sinu poolt allkirjastatud</translation>
+        <translation>See ümbrik on Sinu poolt allkirjastatud</translation>
     </message>
     <message>
         <source>You have not signed this container</source>
@@ -2777,7 +2777,7 @@ Vastavalt &lt;a href=&quot;https://sk.ee/teenused/kehtivuskinnituse-teenus/kehti
     </message>
     <message>
         <source>Your email account has been blocked. To open it, please send an email to toimetaja@eesti.ee or call 663 0215.</source>
-        <translation>Teie e-posti konto on suletud. Avamiseks saatke palun e-kiri aadressil toimetaja@eesti.ee või helistage telefonil 663 0215.</translation>
+        <translation>Sinu e-posti konto on suletud. Avamiseks saatke palun e-kiri aadressil toimetaja@eesti.ee või helistage telefonil 663 0215.</translation>
     </message>
     <message>
         <source>Invalid email address</source>
@@ -2785,7 +2785,7 @@ Vastavalt &lt;a href=&quot;https://sk.ee/teenused/kehtivuskinnituse-teenus/kehti
     </message>
     <message>
         <source>Forwarding is activated and you have been sent an email with activation key. Forwarding will be activated only after confirming the key.</source>
-        <translation>Suunamine on salvestatud, ning sinule on saadetud kiri edasisuunamisaadressi aktiveerimisvõtmega. Suunamine on kasutatav ainult pärast aktiveerimisvõtme sisestamist.</translation>
+        <translation>Suunamine on salvestatud, ning Sinule on saadetud kiri edasisuunamisaadressi aktiveerimisvõtmega. Suunamine on kasutatav ainult pärast aktiveerimisvõtme sisestamist.</translation>
     </message>
     <message>
         <source>Opening</source>

--- a/client/widgets/CardPopup.cpp
+++ b/client/widgets/CardPopup.cpp
@@ -51,10 +51,6 @@ CardPopup::CardPopup(const TokenData &token, const QMap<QString, QSharedPointer<
 			cardData.reset(new QCardInfo);
 			cardData->id = card;
 		}
-		else
-		{
-			Styles::cachedPicture( cardData->id, {cardWidget} );
-		}
 		cardWidget->move(0, 0);
 		cardWidget->update(cardData, card);
 		connect(cardWidget, &CardWidget::selected, this, &CardPopup::activated);
@@ -72,9 +68,6 @@ void CardPopup::update(const QMap<QString, QSharedPointer<QCardInfo>> &cache)
 	{
 		auto cardData = cache[cardWidget->id()];
 		if( cardWidget->isLoading() && !cardData.isNull() )
-		{
 			cardWidget->update(cardData, cardWidget->id());
-			Styles::cachedPicture( cardData->id, {cardWidget} );
-		}
 	}
 }

--- a/client/widgets/CardPopup.h
+++ b/client/widgets/CardPopup.h
@@ -19,7 +19,6 @@
 
 #pragma once 
 
-#include "common_enums.h"
 #include "QCardInfo.h"
 #include "widgets/CardWidget.h"
 #include "widgets/StyledWidget.h"

--- a/client/widgets/ItemList.cpp
+++ b/client/widgets/ItemList.cpp
@@ -216,7 +216,7 @@ void ItemList::init(ItemType item, const QString &header)
 		headerItems = 2;
 	}
 
-	if (itemType == ItemSignature || item == AddedAdresses)
+	if (itemType == ItemSignature || item == AddedAdresses || this->state == SignedContainer)
 	{
 		ui->add->hide();
 	}
@@ -288,10 +288,8 @@ void ItemList::setTerm(const QString &term)
 void ItemList::stateChange( ContainerState state )
 {
 	this->state = state;
-	ui->add->setVisible(state & (SignatureContainers | UnencryptedContainer));
+	ui->add->setVisible(state & (UnsignedContainer | UnsignedSavedContainer | UnencryptedContainer));
 
 	for(auto item: items)
-	{
 		item->stateChange(state);
-	}
 }


### PR DESCRIPTION
- DDKLIEN-106: Disable adding and dropping files to the signed container
- DDKLIEN-116: Do not cache downloaded profile pictures
- DDKLIEN-118: Use "Sina" form everywhere instead of mixed "Sina"&"Teie"

Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>