### PR TITLE
Always load proxy settings on startup

### DIFF
--- a/client/Application.cpp
+++ b/client/Application.cpp
@@ -26,6 +26,7 @@
 #include "QSigner.h"
 #include "DigiDoc.h"
 #include "dialogs/FirstRun.h"
+#include "dialogs/SettingsDialog.h"
 #include "dialogs/WaitDialog.h"
 #include "dialogs/WarningDialog.h"
 
@@ -96,6 +97,7 @@ public:
 				reload();
 		});
 		s.beginGroup( "Client" );
+		SettingsDialog::loadProxy(this);
 	}
 
 	std::string proxyHost() const override

--- a/client/dialogs/SettingsDialog.h
+++ b/client/dialogs/SettingsDialog.h
@@ -47,6 +47,7 @@ public:
 	~SettingsDialog();
 
 	int exec() override;
+	static void loadProxy( const digidoc::Conf *conf );
 
 private Q_SLOTS:
 	void save();
@@ -64,7 +65,6 @@ private:
 	void selectLanguage();
 	void setProxyEnabled();
 	void updateProxy();
-	void loadProxy( const digidoc::Conf *conf );
 	void openDirectory();
 	void updateDiagnostics();
 	void saveDiagnostics();


### PR DESCRIPTION
If proxy settings are provided externally (written to registry / plist),
the client must load proxy settings on startup in order to apply them.

Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>