### PR TITLE
Clean up incorrectly encoded fields of the cert

### DIFF
--- a/client/dialogs/CertificateDetails.h
+++ b/client/dialogs/CertificateDetails.h
@@ -41,6 +41,7 @@ public:
 	~CertificateDetails();
 
 	void saveCert();
+	static QString decodeCN(const QString &cn);
 	int exec() override;
 
 public slots:

--- a/client/dialogs/SettingsDialog.cpp
+++ b/client/dialogs/SettingsDialog.cpp
@@ -116,6 +116,13 @@ void SettingsDialog::initUI()
 	ui->btnMenuGeneral->setFont(condensed12);
 	ui->btnMenuSigning->setFont(condensed12);
 	ui->btnMenuCertificate->setFont(condensed12);
+	ui->btnMenuCertificate->setText(tr("ACCESS CERTIFICATE",
+#ifdef Q_OS_WIN
+		"win"
+#else
+		"not-win"
+#endif
+	));
 	ui->btnMenuProxy->setFont(condensed12);
 	ui->btnMenuDiagnostics->setFont(condensed12);
 	ui->btnMenuInfo->setFont(condensed12);
@@ -197,6 +204,13 @@ void SettingsDialog::initUI()
 	ui->btnNavUseByDefault->setFont(condensed12);
 	ui->btnNavInstallManually->setFont(condensed12);
 	ui->btnNavShowCertificate->setFont(condensed12);
+	ui->btnNavShowCertificate->setText(tr("SHOW CERTIFICATE",
+#ifdef Q_OS_WIN
+		"win"
+#else
+		"not-win"
+#endif
+	));
 	ui->btnFirstRun->setFont(condensed12);
 	ui->btnNavSaveReport->setFont(condensed12);
 	ui->btnCheckConnection->setFont(condensed12);

--- a/client/dialogs/SettingsDialog.cpp
+++ b/client/dialogs/SettingsDialog.cpp
@@ -51,6 +51,31 @@
 #include <QtNetwork/QNetworkProxy>
 
 
+bool isDoubleEncodedUtf8(const QByteArray &str)
+{
+	// Detect double-encoded UTF-8 strings.
+	// E.g. 'Infosüsteemi' encoded to UTF-8, and then decoded to Latin1 is
+	// displayed as 'InfosÃ¼steemi'; In python3:
+	// > 'Infosüsteemi'.encode('utf-8').decode('latin1').encode('utf-8')
+	// > b'Infos\xc3\x83\xc2\xbcsteemi'
+	// > # Reverse
+	// b'Infos\xc3\x83\xc2\xbcsteemi'.decode('utf-8').encode('latin1').decode('utf-8')
+	// See "double" encoded UTF-8 sequence within Latin-1 Supplement:
+	// http://blogs.perl.org/users/chansen/2010/10/coping-with-double-encoded-utf-8.html
+	for(int i = 0; i < str.length() - 3; ++i)
+	{
+		if(str[i] == '\xc3' && str[i+2] == '\xc2')
+		{
+			if( (str[i+1] >= '\x82' && str[i+1] <= '\x84') &&
+				(str[i+3] >= '\x80' && str[i+3] <= '\xBF'))
+				return true;
+			i += 3;
+		}
+	}
+
+	return false;
+}
+
 SettingsDialog::SettingsDialog(QWidget *parent, QString appletVersion)
 : QDialog(parent)
 , ui(new Ui::SettingsDialog)
@@ -479,17 +504,25 @@ void SettingsDialog::updateCert()
 {
 	QSslCertificate c = AccessCert::cert();
 	if( !c.isNull() )
+	{
+		auto cn = SslCertificate(c).subjectInfo(QSslCertificate::CommonName);
+		auto cnUtf8 = cn.toUtf8();
+		if(isDoubleEncodedUtf8(cnUtf8))
+			cn = QString(cnUtf8).toLatin1();
 		ui->txtAccessCert->setText(
 			tr("FREE_CERT_EXCEEDED") + "<br /><br />" +
 			QString(tr("Issued to: %1<br />Valid to: %2 %3"))
-				.arg( SslCertificate(c).subjectInfo( QSslCertificate::CommonName ) )
+				.arg( cn )
 				.arg( c.expiryDate().toString("dd.MM.yyyy") )
 				.arg( !SslCertificate(c).isValid() ? 
 					"<font color='red'>(" + tr("expired") + ")</font>" : "" ) );
+	}
 	else
+	{
 		ui->txtAccessCert->setText( 
 			tr("FREE_CERT_EXCEEDED") + "<br /><br />" +
 			"<b>" + tr("Server access certificate is not installed.") + "</b>" );
+	}
 	ui->txtAccessCert->adjustSize();
 	ui->btnNavShowCertificate->setEnabled( !c.isNull() );
 	ui->btnNavShowCertificate->setProperty( "cert", QVariant::fromValue( c ) );

--- a/client/dialogs/SettingsDialog.ui
+++ b/client/dialogs/SettingsDialog.ui
@@ -220,6 +220,12 @@ QPushButton:!checked{
          </item>
          <item>
           <widget class="QPushButton" name="btnMenuCertificate">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="minimumSize">
             <size>
              <width>0</width>
@@ -251,6 +257,9 @@ QPushButton:!checked{
             <string>ACCESS CERTIFICATE</string>
            </property>
            <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <property name="flat">
             <bool>true</bool>
            </property>
           </widget>
@@ -1327,19 +1336,19 @@ background-color: #FFFFFF;
            <rect>
             <x>21</x>
             <y>442</y>
-            <width>65</width>
+            <width>75</width>
             <height>16</height>
            </rect>
           </property>
           <property name="minimumSize">
            <size>
-            <width>65</width>
+            <width>75</width>
             <height>16</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
-            <width>65</width>
+            <width>75</width>
             <height>16</height>
            </size>
           </property>
@@ -1654,7 +1663,7 @@ QRadioButton::indicator::checked {
            </size>
           </property>
           <property name="echoMode">
-            <enum>QLineEdit::Password</enum>
+           <enum>QLineEdit::Password</enum>
           </property>
          </widget>
          <widget class="QLabel" name="lblProxyHost">
@@ -1918,7 +1927,7 @@ p, li { white-space: pre-wrap; }
           <property name="geometry">
            <rect>
             <x>339</x>
-            <y>35</y>
+            <y>31</y>
             <width>111</width>
             <height>61</height>
            </rect>
@@ -1940,9 +1949,9 @@ p, li { white-space: pre-wrap; }
           <property name="geometry">
            <rect>
             <x>10</x>
-            <y>104</y>
+            <y>100</y>
             <width>771</width>
-            <height>81</height>
+            <height>86</height>
            </rect>
           </property>
           <property name="text">
@@ -2314,6 +2323,12 @@ QPushButton:disabled {
       </item>
       <item>
        <widget class="QPushButton" name="btnNavInstallManually">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="minimumSize">
          <size>
           <width>120</width>
@@ -2358,6 +2373,12 @@ QPushButton:disabled {
       </item>
       <item>
        <widget class="QPushButton" name="btnNavShowCertificate">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="minimumSize">
          <size>
           <width>120</width>

--- a/client/dialogs/SignatureDialog.cpp
+++ b/client/dialogs/SignatureDialog.cpp
@@ -160,7 +160,7 @@ SignatureDialog::SignatureDialog(const DigiDocSignature &signature, QWidget *par
 	horzHeaders << tr("Attribute") << tr("Value");
 	t->setHeaderLabels(horzHeaders);
 
-	addItem( t, tr("Signer's Certificate issuer"), c.issuerInfo( QSslCertificate::CommonName ) );
+	addItem( t, tr("Signer's Certificate issuer"), CertificateDetails::decodeCN(c.issuerInfo(QSslCertificate::CommonName)));
 	addItem( t, tr("Signer's Certificate"), c );
 	addItem( t, tr("Signature method"), QUrl( s.signatureMethod() ) );
 	addItem( t, tr("Container format"), s.parent()->mediaType() );
@@ -227,7 +227,7 @@ void SignatureDialog::addItem( QTreeWidget *view, const QString &variable, const
 {
 	QTreeWidgetItem *i = new QTreeWidgetItem( view );
 	i->setText( 0, variable );
-	QLabel *b = new QLabel( "<a href='cert'>" + SslCertificate(value).subjectInfo( QSslCertificate::CommonName ) + "</a>", view );
+	QLabel *b = new QLabel( "<a href='cert'>" + CertificateDetails::decodeCN(SslCertificate(value).subjectInfo(QSslCertificate::CommonName)) + "</a>", view );
 #ifdef Q_OS_MAC
 	b->setFont(Styles::font(Styles::Regular, 13));
 #else

--- a/client/translations/et.ts
+++ b/client/translations/et.ts
@@ -1656,7 +1656,7 @@ saada on pöörduda &lt;u&gt;klienditeeninduspunkti&lt;/u&gt; poole.&lt;/li&gt;
     </message>
     <message>
         <source>SHOW CERTIFICATE</source>
-        <translation>NÄITA TÕENDIT</translation>
+        <translation>NÄITA TŌENDIT</translation>
     </message>
     <message>
         <source>USE DEFAULT</source>

--- a/client/translations/et.ts
+++ b/client/translations/et.ts
@@ -1614,8 +1614,14 @@ saada on pöörduda &lt;u&gt;klienditeeninduspunkti&lt;/u&gt; poole.&lt;/li&gt;
         <translation>ALLKIRJASTAMINE</translation>
     </message>
     <message>
+        <comment>not-win</comment>
         <source>ACCESS CERTIFICATE</source>
         <translation>JUURDEPÄÄSUTÕEND</translation>
+    </message>
+    <message>
+        <comment>win</comment>
+        <source>ACCESS CERTIFICATE</source>
+        <translation>JUURDEPÄÄSUTŌEND</translation>
     </message>
     <message>
         <source>PROXY</source>
@@ -1655,6 +1661,12 @@ saada on pöörduda &lt;u&gt;klienditeeninduspunkti&lt;/u&gt; poole.&lt;/li&gt;
         <translation>SALVESTA DIAGNOSTIKA</translation>
     </message>
     <message>
+        <comment>not-win</comment>
+        <source>SHOW CERTIFICATE</source>
+        <translation>NÄITA TÕENDIT</translation>
+    </message>
+    <message>
+        <comment>win</comment>
         <source>SHOW CERTIFICATE</source>
         <translation>NÄITA TŌENDIT</translation>
     </message>


### PR DESCRIPTION
DDKLIEN-122: 
- Detect incorrectly encoded certificate's common name and
   clean it up when showing in settings and certificate dialogs
- Use different glyph on Windows to show uppercase Õ in Settings
- Minor UI fixes in Settings dlg

Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>