### PR TITLE
Improve Ubuntu packaging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ script: case ${TARGET} in
       apt-get update -qq;
       apt-get install -y libdigidocpp-dev;
       export VERSION=$(grep project CMakeLists.txt | egrep -o "([0-9]{1,}\.)+[0-9]{1,}").${BUILD_NUMBER};
-      dh_make --createorig --addmissing --defaultless -y -p qdigidoc4_${VERSION};
+      dh_make --createorig --addmissing --copyright lgpl2 --defaultless -y -p qdigidoc4_${VERSION};
       dch --distribution $(lsb_release -cs) -v ${VERSION} "Release ${VERSION}.";
       dpkg-buildpackage -rfakeroot -us -uc;
       set +e;

--- a/client/qdigidoc4.desktop
+++ b/client/qdigidoc4.desktop
@@ -3,7 +3,7 @@ Encoding=UTF-8
 Type=Application
 
 Exec=qdigidoc4 %F
-Icon=qdigidoc-client
+Icon=qdigidoc4
 
 Name=DigiDoc4 Client
 Name[et]=DigiDoc4 klient

--- a/debian/control
+++ b/debian/control
@@ -24,6 +24,8 @@ Depends:
  ${shlibs:Depends} ${misc:Depends}
 Conflicts:
  libdigidocpp0 (<<3.0)
+Replaces:
+ qdigidoc (<< 3.13.6)
 Description: Estonian digital signature application
  ID-software allows you to use your ID-card electronically – use
  private and governmental e-services, digitally sign documents


### PR DESCRIPTION
- DDKLIEN-104: Allow to overwrite qdigidoc mimetype icons
- DDKLIEN-109: Fix DigiDoc4 Client application icon

Signed-off-by: Toomas Uudisaru toomas.uudisaru@aktors.ee