### PR TITLE
Do not check expiry in case of empty certificate

### DIFF
--- a/client/MainWindow.cpp
+++ b/client/MainWindow.cpp
@@ -997,7 +997,8 @@ void MainWindow::showCardStatus()
 			ui->infoStack->update(*cardInfo);
 			const SslCertificate &signCert = t.cert();
 			ui->accordion->updateInfo(*cardInfo, authCert, signCert);
-			ui->myEid->invalidIcon(!authCert.isValid() || !signCert.isValid());
+			ui->myEid->invalidIcon((!authCert.isNull() && !authCert.isValid()) || 
+				(!signCert.isNull() && !signCert.isValid()));
 			updateCardWarnings();
  		}
 	}

--- a/client/MainWindow_MyEID.cpp
+++ b/client/MainWindow_MyEID.cpp
@@ -78,8 +78,11 @@ bool MainWindow::checkExpiration()
 	int expiresIn = 106;
 	for(const SslCertificate &cert: {qApp->signer()->tokenauth().cert(), qApp->signer()->tokensign().cert()})
 	{
-		expiresIn = std::min<int>(expiresIn,
-			QDateTime::currentDateTime().daysTo(cert.expiryDate().toLocalTime()));
+		if(!cert.isNull())
+		{
+			expiresIn = std::min<int>(expiresIn,
+				QDateTime::currentDateTime().daysTo(cert.expiryDate().toLocalTime()));
+		}
 	}
 
 	if(expiresIn <= 0)


### PR DESCRIPTION
- DDKLIEN-125: Do not check expiry of missing certificate, e.g. in case
  of e-Stamp if auth certificate is not present

Signed-off-by: Toomas Uudisaru toomas.uudisaru@aktors.ee