### PR TITLE
Destroy waitdlg instead of hiding on filedlg open

### DIFF
--- a/client/Application.cpp
+++ b/client/Application.cpp
@@ -906,7 +906,7 @@ void Application::waitForTSL( const QString &file )
 	if( d->ready )
 		return;
 
-	auto hider = WaitDialog::hider();
+	WaitDialogHider hider;
 	QProgressDialog p( tr("Loading TSL lists"), QString(), 0, 0, qApp->mainWindow() );
 	p.setWindowFlags( (Qt::Dialog | Qt::CustomizeWindowHint | Qt::MSWindowsFixedSizeDialogHint ) & ~Qt::WindowTitleHint );
 	p.setWindowModality( Qt::ApplicationModal );

--- a/client/MainWindow.cpp
+++ b/client/MainWindow.cpp
@@ -354,8 +354,7 @@ bool MainWindow::decrypt()
 	if(!cryptoDoc)
 		return false;
 
-	WaitDialog waitDialog(this);
-	waitDialog.open();
+	WaitDialogHolder waitDialog(this);
 
 	return cryptoDoc->decrypt();
 }
@@ -413,9 +412,7 @@ bool MainWindow::encrypt()
 	if(!cryptoDoc)
 		return false;
 
-	WaitDialog waitDialog(this);
-	waitDialog.setText(tr("Encrypting"));
-	waitDialog.open();
+	WaitDialogHolder waitDialog(this, tr("Encrypting"));
 
 	return cryptoDoc->encrypt();
 }
@@ -769,9 +766,7 @@ void MainWindow::openFiles(const QStringList &files, bool addFile)
 
 	if(create || current != page)
 	{
-		WaitDialog waitDialog(this);
-		waitDialog.setText(tr("Opening"));
-		waitDialog.open();
+		WaitDialogHolder waitDialog(this, tr("Opening"));
 		navigateToPage(page, content, create);
 	}
 }
@@ -920,7 +915,7 @@ QString MainWindow::selectFile( const QString &title, const QString &filename, b
 		if( ext == "adoc" ) active = adoc;
 	}
 
-	auto hider = WaitDialog::hider();
+	WaitDialogHider hider;
 	return FileDialog::getSaveFileName( this, title, filename, exts.join(";;"), &active );
 }
 
@@ -1073,9 +1068,7 @@ bool MainWindow::sign()
 	AccessCert access(this);
 	if( !access.validate() )
 		return false;
-	WaitDialog waitDialog(this);
-	waitDialog.setText(tr("Signing"));
-	waitDialog.open();
+	WaitDialogHolder waitDialog(this, tr("Signing"));
 
 	QString role = Settings(qApp->applicationName()).value( "Client/Role" ).toString();
 	QString city = Settings(qApp->applicationName()).value( "Client/City" ).toString();

--- a/client/dialogs/PinPopup.cpp
+++ b/client/dialogs/PinPopup.cpp
@@ -155,10 +155,18 @@ void PinPopup::textEdited( const QString &text )
 int PinPopup::exec()
 {
 	WaitDialogHider hider;
-	Overlay overlay(parentWidget());
-	overlay.show();
-	auto rc = QDialog::exec();
-	overlay.close();
+	int rc = 0;
+	if (hider.hasOverlay())
+	{
+		rc = QDialog::exec();
+	}
+	else
+	{
+		Overlay overlay(parentWidget());
+		overlay.show();
+		rc = QDialog::exec();
+		overlay.close();
+	}
 
 	return rc;
 }

--- a/client/dialogs/PinPopup.cpp
+++ b/client/dialogs/PinPopup.cpp
@@ -153,8 +153,8 @@ void PinPopup::textEdited( const QString &text )
 }
 
 int PinPopup::exec()
-{ 
-	auto hider = WaitDialog::hider();
+{
+	WaitDialogHider hider;
 	Overlay overlay(parentWidget());
 	overlay.show();
 	auto rc = QDialog::exec();

--- a/client/dialogs/WaitDialog.cpp
+++ b/client/dialogs/WaitDialog.cpp
@@ -29,6 +29,8 @@
 #include <QMovie>
 
 WaitDialogHider::WaitDialogHider()
+: overlay(nullptr)
+, parent(nullptr)
 {
 	WaitDialog *d = WaitDialog::instance();
 	if(d)
@@ -48,6 +50,11 @@ WaitDialogHider::~WaitDialogHider()
 		d->setText(text);
 		d->open();
 	}
+}
+
+bool WaitDialogHider::hasOverlay()
+{
+	return overlay != nullptr;
 }
 
 

--- a/client/dialogs/WaitDialog.h
+++ b/client/dialogs/WaitDialog.h
@@ -30,6 +30,8 @@ public:
 	WaitDialogHider();
 	~WaitDialogHider();
 
+	bool hasOverlay();
+
 private:
 	QString text;
 	Overlay *overlay;

--- a/client/dialogs/WaitDialog_p.h
+++ b/client/dialogs/WaitDialog_p.h
@@ -19,29 +19,37 @@
 
 #pragma once
 
-#include <QString>
-#include <QWidget>
+#include <QDialog>
+
+namespace Ui {
+class WaitDialog;
+}
 
 class Overlay;
 
-class WaitDialogHider
+class WaitDialog : public QDialog
 {
+	Q_OBJECT
+
 public:
-	WaitDialogHider();
-	~WaitDialogHider();
+	explicit WaitDialog(QWidget *parent = nullptr, Overlay *o = nullptr);
+	~WaitDialog();
+
+	int exec() override;
+	void open() override;
+	QString text();
+
+	static WaitDialog* create(QWidget *parent, Overlay *o = nullptr);
+	static void destroy();
+
+	void closeOverlay();
+	Overlay* detachOverlay();
+	static WaitDialog* instance();
+	void showOverlay();
+	void setText(const QString &text);
 
 private:
-	QString text;
-	Overlay *overlay;
-	QWidget *parent;
-};
-
-
-class WaitDialogHolder
-{
-public:
-	WaitDialogHolder(QWidget *parent, const QString& text = QString());
-	~WaitDialogHolder();
-
-	void close();
+	Ui::WaitDialog *ui;
+	Overlay *overlay = nullptr;
+	static WaitDialog *waitDialog;
 };

--- a/client/util/FileUtil.cpp
+++ b/client/util/FileUtil.cpp
@@ -87,7 +87,7 @@ QString FileUtil::create(const QFileInfo &fileInfo, const QString &extension, co
 	if(QFile::exists(fileName))
 	{
 #endif
-		auto hider = WaitDialog::hider();
+		WaitDialogHider hider;
 		QString capitalized = type[0].toUpper() + type.mid(1);
 		fileName = FileDialog::getSaveFileName(qApp->activeWindow(), qApp->tr("Create %1").arg(type), fileName,
 						QString("%1 (*%2)").arg(capitalized).arg(extension));


### PR DESCRIPTION
- DDKLIEN-54: Destroy wait dialog when File Dialog is opened; on Linux
  modal dialog is not properly hidden.

Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>