### PR TITLE
Handle tokens with only one certificate correctly

### DIFF
--- a/client/QSigner.cpp
+++ b/client/QSigner.cpp
@@ -333,10 +333,14 @@ void QSigner::run()
 				st.setCert( QSslCertificate() );
 			}
 
+			// Some tokens (e.g. e-Seals) can have only authentication or signing cert;
+			// Do not select first card in case if only one of the tokens is empty.
+			bool update = at.card().isEmpty() && st.card().isEmpty();
+
 			// if none is selected select first from cardlist
-			if( at.card().isEmpty() && !acards.isEmpty() )
+			if( update && !acards.isEmpty() )
 				at.setCard( acards.first() );
-			if( st.card().isEmpty() && !scards.isEmpty() )
+			if( update && !scards.isEmpty() )
 				st.setCard( scards.first() );
 
 			if( acards.contains( at.card() ) && at.cert().isNull() ) // read auth cert
@@ -429,7 +433,7 @@ void QSigner::selectAuthCard( const QString &card )
 	TokenData t = d->auth;
 	t.setCard( card );
 	t.setCert( QSslCertificate() );
-	Q_EMIT signDataChanged(d->auth = t);
+	Q_EMIT authDataChanged(d->auth = t);
 }
 
 void QSigner::selectSignCard( const QString &card )


### PR DESCRIPTION
DDKLIEN-131: If several tokens are connected and new token is selected
that has only one certificate (e.g. e-Seal with signing cert), then DD4
selects incorrectly the missing cert from card/token that is not
currently active.

Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>