### PR TITLE
Mobile progress dialog's font/style

### DIFF
--- a/client/MainWindow.cpp
+++ b/client/MainWindow.cpp
@@ -976,6 +976,7 @@ void MainWindow::showCardStatus()
 		{
 			ui->infoStack->clearData();
 			ui->accordion->clear();
+			clearWarning(WarningType::UpdateCertWarning);
 		}
 
 		ui->cardInfo->update(cardInfo, t.card());

--- a/client/dialogs/MobileProgress.cpp
+++ b/client/dialogs/MobileProgress.cpp
@@ -85,7 +85,15 @@ MobileProgress::MobileProgress( QWidget *parent )
 	connect(cancel, &QPushButton::clicked, this, &MobileProgress::stop);
 #endif
 
-	cancel->setFont(Styles::font(Styles::Condensed, 14));
+	QFont condensed12 = Styles::font( Styles::Condensed, 12 );
+	QFont condensed14 = Styles::font( Styles::Condensed, 14 );
+	QFont header = Styles::font( Styles::Condensed, 20 );
+	header.setWeight( QFont::Bold );
+	code->setFont( header );
+	labelError->setFont( condensed12 );
+	signProgressBar->setFont( condensed12 );
+
+	cancel->setFont( condensed14 );
 	connect(cancel, &QPushButton::clicked, this, &MobileProgress::reject);
 
 	manager = new QNetworkAccessManager( this );

--- a/client/dialogs/MobileProgress.cpp
+++ b/client/dialogs/MobileProgress.cpp
@@ -72,6 +72,9 @@ MobileProgress::MobileProgress( QWidget *parent )
 	setupUi( this );
 	code->setBuddy( signProgressBar );
 
+	setWindowFlags( Qt::Dialog | Qt::CustomizeWindowHint );
+	setWindowModality( Qt::ApplicationModal );
+
 	statusTimer = new QTimeLine( signProgressBar->maximum() * 1000, this );
 	statusTimer->setCurveShape( QTimeLine::LinearCurve );
 	statusTimer->setFrameRange( signProgressBar->minimum(), signProgressBar->maximum() );


### PR DESCRIPTION
1. Fix Mobile Progress dialog's font sizes/styles.
    Remove title bar from Mobile Progress dialog.
2. When user quickly changes the ID card with 'Update' certificate warning to other ID card (having no 'Update' cert. warn.) the previous card's warning should not be shown.
