### PR TITLE
Filenames with UTF-8 diacritic marks in mobile signing

### DIFF
--- a/client/DigiDoc.cpp
+++ b/client/DigiDoc.cpp
@@ -334,6 +334,14 @@ QString SDocumentModel::data(int row) const
 	return from(doc->b->dataFiles().at(row)->fileName());
 }
 
+QString SDocumentModel::fileId(int row) const
+{
+	if(row >= rowCount())
+		return QString();
+
+	return QString::fromUtf8(doc->b->dataFiles().at(row)->fileName().c_str());
+}
+
 QString SDocumentModel::mime(int row) const
 {
 	if(row >= rowCount())

--- a/client/DigiDoc.h
+++ b/client/DigiDoc.h
@@ -95,6 +95,7 @@ public:
 	void addFile(const QString &file, const QString &mime = "application/octet-stream") override;
 	void addTempFiles(const QStringList &files) override;
 	QString data(int row) const override;
+	QString fileId(int row) const override;
 	QString mime(int row) const override;
 	bool removeRows(int row, int count) override;
 	int rowCount() const override;

--- a/client/DocumentModel.h
+++ b/client/DocumentModel.h
@@ -31,6 +31,7 @@ public:
 	virtual void addFile(const QString &file, const QString &mime = "application/octet-stream") = 0;
 	virtual void addTempFiles(const QStringList &files) = 0;
 	virtual QString data(int row) const = 0;
+	virtual QString fileId(int row) const = 0;
 	virtual QString mime(int row) const = 0;
 	virtual bool removeRows(int row, int count) = 0;
 	virtual int rowCount() const = 0;

--- a/client/crypto/CryptoDoc.cpp
+++ b/client/crypto/CryptoDoc.cpp
@@ -857,6 +857,11 @@ QString CDocumentModel::data(int row) const
 	return f.name;
 }
 
+QString CDocumentModel::fileId(int row) const
+{
+	return data(row);
+}
+
 QString CDocumentModel::mime(int row) const
 {
 	const CryptoDocPrivate::File &f = d->files.at(row);

--- a/client/crypto/CryptoDoc.h
+++ b/client/crypto/CryptoDoc.h
@@ -34,6 +34,7 @@ public:
 	void addFile(const QString &file, const QString &mime = "application/octet-stream") override;
 	void addTempFiles(const QStringList &files) override;
 	QString data(int row) const override;
+	QString fileId(int row) const override;
 	QString mime(int row) const override;
 	bool removeRows(int row, int count) override;
 	int rowCount() const override;

--- a/client/dialogs/MobileProgress.cpp
+++ b/client/dialogs/MobileProgress.cpp
@@ -69,8 +69,8 @@ MobileProgress::MobileProgress( QWidget *parent )
 	mobileResults["Certificate status unknown"] = tr("Your Mobile-ID service is not activated.");
 	mobileResults["Certificate is revoked"] = tr("Mobile-ID user certificates are revoked or suspended.");
 
-	setWindowFlags( Qt::Dialog | Qt::FramelessWindowHint );
 	setupUi( this );
+	setWindowFlags( Qt::Dialog | Qt::CustomizeWindowHint );
 	code->setBuddy( signProgressBar );
 
 	statusTimer = new QTimeLine( signProgressBar->maximum() * 1000, this );

--- a/client/dialogs/MobileProgress.cpp
+++ b/client/dialogs/MobileProgress.cpp
@@ -69,6 +69,7 @@ MobileProgress::MobileProgress( QWidget *parent )
 	mobileResults["Certificate status unknown"] = tr("Your Mobile-ID service is not activated.");
 	mobileResults["Certificate is revoked"] = tr("Mobile-ID user certificates are revoked or suspended.");
 
+	setWindowFlags( Qt::Dialog | Qt::FramelessWindowHint );
 	setupUi( this );
 	code->setBuddy( signProgressBar );
 
@@ -264,7 +265,7 @@ void MobileProgress::sign( const DigiDoc *doc, const QString &ssid, const QStrin
 	{
 		r.writeStartElement( "DataFileDigest" );
 		r.writeAttribute( XML_SCHEMA_INSTANCE, "type", QString( "m:" ).append( "DataFileDigest" ) );
-		r.writeParameter( "Id", m->data(i) );
+		r.writeParameter( "Id", m->fileId(i) );
 		r.writeParameter( "DigestType", "sha256" );
 		r.writeParameter( "DigestValue", doc->getFileDigest( i ).toBase64() );
 		r.writeParameter( "MimeType", m->mime(i) );

--- a/client/dialogs/MobileProgress.ui
+++ b/client/dialogs/MobileProgress.ui
@@ -32,7 +32,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>Signing with Mobile-ID</string>
   </property>
   <property name="styleSheet">
    <string notr="true">border-radius: 2px;


### PR DESCRIPTION
DDKLIEN-143: Fix for mobile signing of file with UTF-8 diacritic mark (e.g. u with diacritic tilde, 
u + 0xcc +0x88) in the name ends with invalid signature.

Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>