### PR TITLE
Recognize eToken with only auth certificate

### DIFF
--- a/client/QCardInfo.h
+++ b/client/QCardInfo.h
@@ -30,4 +30,5 @@ struct QCardInfo
 	int type;
 	bool loading;
 	bool isEResident;
+	bool valid;
 };

--- a/client/QSigner.cpp
+++ b/client/QSigner.cpp
@@ -133,7 +133,7 @@ void QSigner::cacheCardData(const QSet<QString> &cards, bool signingCert)
 		QWin::Certs certs = d->win->certs();
 		for(QWin::Certs::const_iterator i = certs.constBegin(); i != certs.constEnd(); ++i)
 		{
-			if(!d->cache.contains(i.value()) && isMatchingType(i.key(), signingCert))
+			if((!d->cache.contains(i.value()) || !d->cache[i.card()]->valid) && isMatchingType(i.key(), signingCert))
 				d->cache.insert(i.value(), QSharedPointer<QCardInfo>(toCardInfo(i.key())));
 		}
 	}
@@ -330,6 +330,8 @@ void QSigner::run()
 			at.setReaders( readers );
 			st.setCards( scards );
 			st.setReaders( readers );
+
+			qCDebug(SLog) << "Auth cards" << acards << "Sign cards" << scards;
 
 			// check if selected card is still in slot
 			if( !at.card().isEmpty() && !acards.contains( at.card() ) )

--- a/client/QSigner.h
+++ b/client/QSigner.h
@@ -62,11 +62,12 @@ public:
 
 Q_SIGNALS:
 	void authDataChanged( const TokenData &token );
+	void dataChanged();
 	void signDataChanged( const TokenData &token );
 	void error( const QString &msg );
 
 private Q_SLOTS:
-	void cacheCardData(const QSet<QString> &cards);
+	void cacheCardData(const QSet<QString> &cards, bool signingCert);
 	void selectAuthCard( const QString &card );
 	void selectSignCard( const QString &card );
 	void showWarning( const QString &msg );


### PR DESCRIPTION
DDKLIEN-142: If USB hardware token with only authentication cert is selected,
then DigiDoc4 Client must show the information of auth cert on myEID page, enable
encryption and show no card/eSeal for signing.

Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>