### PR TITLE
Recognize eToken with only auth certificate

### DIFF
--- a/client/MainWindow.cpp
+++ b/client/MainWindow.cpp
@@ -952,8 +952,7 @@ void MainWindow::showCardMenu(bool show)
 		cardPopup.reset(new CardPopup(cards(), t.card(), qApp->signer()->cache(), this));
 		// To select active card from several cards in readers ..
 		connect(cardPopup.get(), &CardPopup::activated, qApp->smartcard(), &QSmartCard::selectCard, Qt::QueuedConnection);
-		connect(cardPopup.get(), &CardPopup::activated, qApp->signer(), &QSigner::selectSignCard, Qt::QueuedConnection);
-		connect(cardPopup.get(), &CardPopup::activated, qApp->signer(), &QSigner::selectAuthCard, Qt::QueuedConnection);
+		connect(cardPopup.get(), &CardPopup::activated, qApp->signer(), &QSigner::selectCard, Qt::QueuedConnection);
 		// .. and hide card popup menu
 		connect(cardPopup.get(), &CardPopup::activated, this, &MainWindow::hideCardPopup);
 		cardPopup->show();

--- a/client/MainWindow.cpp
+++ b/client/MainWindow.cpp
@@ -131,7 +131,7 @@ MainWindow::MainWindow( QWidget *parent ) :
 	setAcceptDrops( true );
 
 	// Refresh ID card info in card widget
-	connect(qApp->signer(), &QSigner::signDataChanged, this, &MainWindow::showCardStatus);
+	connect(qApp->signer(), &QSigner::dataChanged, this, &MainWindow::showCardStatus);
 	// Refresh card info on "My EID" page
 	connect(qApp->smartcard(), &QSmartCard::dataChanged, this, &MainWindow::updateMyEid);
 	// Show card pop-up menu
@@ -256,6 +256,12 @@ void MainWindow::buttonClicked( int button )
 	default:
 		break;
 	}
+}
+
+QSet<QString> MainWindow::cards() const
+{
+	return qApp->signer()->tokenauth().cards().toSet()
+		.unite(qApp->signer()->tokensign().cards().toSet());
 }
 
 void MainWindow::changeEvent(QEvent* event)
@@ -936,20 +942,23 @@ void MainWindow::selectPageIcon( PageIcon* page )
 	}
 }
 
-void MainWindow::showCardMenu( bool show )
+void MainWindow::showCardMenu(bool show)
 {
-	if( show )
+	if(show)
 	{
-		cardPopup.reset(new CardPopup(qApp->signer()->tokensign(), qApp->signer()->cache(), this));
+		const TokenData &t = qApp->signer()->tokensign().cert().isNull() ? qApp->signer()->tokenauth()
+			: qApp->signer()->tokensign();
+
+		cardPopup.reset(new CardPopup(cards(), t.card(), qApp->signer()->cache(), this));
 		// To select active card from several cards in readers ..
-		connect( cardPopup.get(), &CardPopup::activated, qApp->smartcard(), &QSmartCard::selectCard, Qt::QueuedConnection );
-		connect( cardPopup.get(), &CardPopup::activated, qApp->signer(), &QSigner::selectSignCard, Qt::QueuedConnection );
-		connect( cardPopup.get(), &CardPopup::activated, qApp->signer(), &QSigner::selectAuthCard, Qt::QueuedConnection );
+		connect(cardPopup.get(), &CardPopup::activated, qApp->smartcard(), &QSmartCard::selectCard, Qt::QueuedConnection);
+		connect(cardPopup.get(), &CardPopup::activated, qApp->signer(), &QSigner::selectSignCard, Qt::QueuedConnection);
+		connect(cardPopup.get(), &CardPopup::activated, qApp->signer(), &QSigner::selectAuthCard, Qt::QueuedConnection);
 		// .. and hide card popup menu
-		connect( cardPopup.get(), &CardPopup::activated, this, &MainWindow::hideCardPopup );
+		connect(cardPopup.get(), &CardPopup::activated, this, &MainWindow::hideCardPopup);
 		cardPopup->show();
 	}
-	else if( cardPopup )
+	else if(cardPopup)
 	{
 		cardPopup->close();
 	}
@@ -958,7 +967,9 @@ void MainWindow::showCardMenu( bool show )
 void MainWindow::showCardStatus()
 {
 	Application::restoreOverrideCursor();
-	TokenData t = qApp->signer()->tokensign();
+	TokenData st = qApp->signer()->tokensign();
+	TokenData at = qApp->signer()->tokenauth();
+	const TokenData &t = st.cert().isNull() ? at : st;
 
 	closeWarnings(-1);
 
@@ -981,17 +992,25 @@ void MainWindow::showCardStatus()
 
 		ui->cardInfo->update(cardInfo, t.card());
 
+		const SslCertificate &authCert = at.cert();
+		const SslCertificate &signCert = st.cert();
 		bool seal = cardInfo->type & SslCertificate::TempelType;
-		const SslCertificate &authCert = qApp->signer()->tokenauth().cert();
-		emit ui->signContainerPage->cardChanged(cardInfo->id, seal);
-		emit ui->cryptoContainerPage->cardChanged(cardInfo->id, seal, authCert.QSslCertificate::serialNumber());
+
+		// Card (e.g. e-Seal) can have only one cert
+		if(!signCert.isNull())
+			emit ui->signContainerPage->cardChanged(cardInfo->id, seal);
+		else
+			emit ui->signContainerPage->cardChanged();
+		if(!authCert.isNull())
+			emit ui->cryptoContainerPage->cardChanged(cardInfo->id, seal, authCert.QSslCertificate::serialNumber());
+		else
+			emit ui->cryptoContainerPage->cardChanged();
 		if(cryptoDoc)
 			ui->cryptoContainerPage->update(cryptoDoc->canDecrypt(authCert));
 
 		if(cardInfo->type & SslCertificate::TempelType)
 		{
 			ui->infoStack->update(*cardInfo);
-			const SslCertificate &signCert = t.cert();
 			ui->accordion->updateInfo(*cardInfo, authCert, signCert);
 			ui->myEid->invalidIcon((!authCert.isNull() && !authCert.isValid()) || 
 				(!signCert.isNull() && !signCert.isValid()));
@@ -1014,7 +1033,7 @@ void MainWindow::showCardStatus()
 	}
 
 	// Combo box to select the cards from
-	if( t.cards().size() > 1 )
+	if(cards().size() > 1)
 	{
 		selector->show();
 	}

--- a/client/MainWindow.h
+++ b/client/MainWindow.h
@@ -93,6 +93,7 @@ protected:
 private:
 	void adjustDrops();
 	void browseOnDisk(const QString &fileName);
+	QSet<QString> cards() const;
 	bool checkExpiration();
 	void clearWarning(int warningType);
 	void clearOverlay();

--- a/client/MainWindow_MyEID.cpp
+++ b/client/MainWindow_MyEID.cpp
@@ -32,9 +32,10 @@
 #include "effects/FadeInNotification.h"
 #include "widgets/WarningItem.h"
 
-#include <common/SslCertificate.h>
 #include <common/Configuration.h>
 #include <common/Settings.h>
+#include <common/SslCertificate.h>
+#include <common/TokenData.h>
 
 #include <QtCore/QJsonObject>
 #include <QDateTime>

--- a/client/QCardInfo.h
+++ b/client/QCardInfo.h
@@ -30,4 +30,5 @@ struct QCardInfo
 	int type;
 	bool loading;
 	bool isEResident;
+	bool valid;
 };

--- a/client/QSigner.cpp
+++ b/client/QSigner.cpp
@@ -464,20 +464,18 @@ void QSigner::run()
 	}
 }
 
-void QSigner::selectAuthCard( const QString &card )
+void QSigner::selectCard(const QString &card)
 {
 	TokenData t = d->auth;
 	t.setCard( card );
 	t.setCert( QSslCertificate() );
 	Q_EMIT authDataChanged(d->auth = t);
-}
 
-void QSigner::selectSignCard( const QString &card )
-{
-	TokenData t = d->sign;
+	t = d->sign;
 	t.setCard( card );
 	t.setCert( QSslCertificate() );
 	Q_EMIT signDataChanged(d->sign = t);
+	Q_EMIT dataChanged();
 }
 
 void QSigner::showWarning( const QString &msg )

--- a/client/QSigner.cpp
+++ b/client/QSigner.cpp
@@ -53,6 +53,14 @@ constexpr typename std::add_const<T>::type& qAsConst(T& t) noexcept
 }
 #endif
 
+bool isMatchingType(const SslCertificate &cert)
+{
+	// Check if cert is signing or authentication cert
+	return cert.keyUsage().contains(SslCertificate::KeyEncipherment) ||
+		   cert.keyUsage().contains(SslCertificate::KeyAgreement) ||
+		   cert.keyUsage().contains(SslCertificate::NonRepudiation);
+}
+
 QCardInfo *toCardInfo(const SslCertificate &c)
 {
 	QCardInfo *ci = new QCardInfo;
@@ -62,6 +70,7 @@ QCardInfo *toCardInfo(const SslCertificate &c)
 	ci->isEResident = c.subjectInfo("O").contains("E-RESIDENT");
 	ci->loading = false;
 	ci->type = c.type();
+	ci->valid = c.isValid();
 
 	if(c.type() & SslCertificate::TempelType)
 	{
@@ -122,7 +131,7 @@ void QSigner::cacheCardData(const QSet<QString> &cards)
 		QWin::Certs certs = d->win->certs();
 		for(QWin::Certs::const_iterator i = certs.constBegin(); i != certs.constEnd(); ++i)
 		{
-			if(!d->cache.contains(i.value()) && i.key().keyUsage().contains(SslCertificate::NonRepudiation))
+			if((!d->cache.contains(i.value()) || !d->cache[i.value()]->valid) && isMatchingType(i.key()))
 				d->cache.insert(i.value(), QSharedPointer<QCardInfo>(toCardInfo(i.key())));
 		}
 	}
@@ -132,10 +141,10 @@ void QSigner::cacheCardData(const QSet<QString> &cards)
 		QList<TokenData> pkcs11 = d->pkcs11->tokens();
 		for(const TokenData &i: qAsConst(pkcs11))
 		{
-			if(!d->cache.contains(i.card()))
+			if(!d->cache.contains(i.card()) || !d->cache[i.card()]->valid)
 			{
 				auto sslCert = SslCertificate(i.cert());
-				if(sslCert.keyUsage().contains(SslCertificate::NonRepudiation))
+				if(isMatchingType(sslCert))
 					d->cache.insert(i.card(), QSharedPointer<QCardInfo>(toCardInfo(sslCert)));
 			}
 		}
@@ -320,6 +329,8 @@ void QSigner::run()
 			st.setCards( scards );
 			st.setReaders( readers );
 
+			qCDebug(SLog) << "Auth cards" << acards << "Sign cards" << scards;
+
 			// check if selected card is still in slot
 			if( !at.card().isEmpty() && !acards.contains( at.card() ) )
 			{
@@ -337,13 +348,21 @@ void QSigner::run()
 			// Do not select first card in case if only one of the tokens is empty.
 			bool update = at.card().isEmpty() && st.card().isEmpty();
 
-			// if none is selected select first from cardlist
-			if( update && !acards.isEmpty() )
-				at.setCard( acards.first() );
-			if( update && !scards.isEmpty() )
-				st.setCard( scards.first() );
+			// if none is selected then pick first card with signing cert;
+			// if no signing certs then pick first card with auth cert
+			if(update && !scards.isEmpty())
+				st.setCard(scards.first());
+			if(update && !acards.isEmpty())
+			{
+				if(st.card().isEmpty())
+					at.setCard(acards.first());
+				else if(acards.contains(st.card()))
+					at.setCard(st.card());
+			}
 
-			if( acards.contains( at.card() ) && at.cert().isNull() ) // read auth cert
+			// read auth cert; if several cards with the same id exist (e.g. e-token
+			// with expired and valid cert), then pick first valid cert with the id.
+			if( acards.contains( at.card() ) && at.cert().isNull() )
 			{
 #ifdef Q_OS_WIN
 				if(d->win)
@@ -355,7 +374,8 @@ void QSigner::run()
 							i.key().keyUsage().contains(SslCertificate::KeyAgreement)))
 						{
 							at.setCert(i.key());
-							break;
+							if(i.key().isValid())
+								break;
 						}
 					}
 				}
@@ -364,19 +384,23 @@ void QSigner::run()
 				{
 					for(const TokenData &i: qAsConst(pkcs11))
 					{
+						SslCertificate sslCert(i.cert());
 						if(i.card() == at.card() &&
-							(SslCertificate(i.cert()).keyUsage().contains(SslCertificate::KeyEncipherment) ||
-							SslCertificate(i.cert()).keyUsage().contains(SslCertificate::KeyAgreement)))
+							(sslCert.keyUsage().contains(SslCertificate::KeyEncipherment) ||
+							sslCert.keyUsage().contains(SslCertificate::KeyAgreement)))
 						{
 							at.setCert( i.cert() );
 							at.setFlags( i.flags() );
-							break;
+							if(sslCert.isValid())
+								break;
 						}
 					}
 				}
 			}
 
-			if( scards.contains( st.card() ) && st.cert().isNull() ) // read sign cert
+			// read sign cert; if several cards with the same id exist (e.g. e-token
+			// with expired and valid cert), then pick first valid cert with the id.
+			if( scards.contains( st.card() ) && st.cert().isNull() )
 			{
 				qCDebug(SLog) << "Read sign cert" << st.card();
 #ifdef Q_OS_WIN
@@ -389,7 +413,8 @@ void QSigner::run()
 							i.key().keyUsage().contains(SslCertificate::NonRepudiation))
 						{
 							st.setCert(i.key());
-							break;
+							if(i.key().isValid())
+								break;
 						}
 					}
 				}
@@ -398,26 +423,37 @@ void QSigner::run()
 				{
 					for(const TokenData &i: qAsConst(pkcs11))
 					{
-						if( i.card() == st.card() && SslCertificate( i.cert() ).keyUsage().contains( SslCertificate::NonRepudiation ) )
+						SslCertificate sslCert(i.cert());
+						if( i.card() == st.card() && sslCert.keyUsage().contains( SslCertificate::NonRepudiation ) )
 						{
 							st.setCert( i.cert() );
 							st.setFlags( i.flags() );
-							break;
+							if(sslCert.isValid())
+								break;
 						}
 					}
 				}
 				qCDebug(SLog) << "Cert is empty:" << st.cert().isNull();
 			}
 
-			auto added = scards.toSet().subtract(d->cache.keys().toSet());
+			auto added = scards.toSet().unite(acards.toSet()).subtract(d->cache.keys().toSet());
 			if(!added.isEmpty())
 				cacheCardData(added);
 
+			bool changed = false;
 			// update data if something has changed
-			if( aold != at )
+			if(aold != at)
+			{
+				changed = true;
 				Q_EMIT authDataChanged(d->auth = at);
-			if( sold != st )
+			}
+			if(sold != st)
+			{
+				changed = true;
 				Q_EMIT signDataChanged(d->sign = st);
+			}
+			if(changed)
+				Q_EMIT dataChanged();
 			d->smartcard->reloadCard(st.card(), d->api != QSigner::CAPI);
 
 			QCardLock::instance().readUnlock();

--- a/client/QSigner.h
+++ b/client/QSigner.h
@@ -62,6 +62,7 @@ public:
 
 Q_SIGNALS:
 	void authDataChanged( const TokenData &token );
+	void dataChanged();
 	void signDataChanged( const TokenData &token );
 	void error( const QString &msg );
 

--- a/client/QSigner.h
+++ b/client/QSigner.h
@@ -68,8 +68,7 @@ Q_SIGNALS:
 
 private Q_SLOTS:
 	void cacheCardData(const QSet<QString> &cards);
-	void selectAuthCard( const QString &card );
-	void selectSignCard( const QString &card );
+	void selectCard(const QString &card);
 	void showWarning( const QString &msg );
 
 private:

--- a/client/dialogs/SettingsDialog.cpp
+++ b/client/dialogs/SettingsDialog.cpp
@@ -287,7 +287,7 @@ void SettingsDialog::initUI()
 	connect( ui->btnMenuInfo, &QPushButton::clicked, this, [this](){ changePage(ui->btnMenuInfo); ui->stackedWidget->setCurrentIndex(5); } );
 
 	connect( this, &SettingsDialog::finished, this, &SettingsDialog::save );
-	connect( this, &SettingsDialog::finished, this, [this](){ QApplication::restoreOverrideCursor(); } );
+	connect( this, &SettingsDialog::finished, this, [](){ QApplication::restoreOverrideCursor(); } );
 
 	connect( ui->btGeneralChooseDirectory, &QPushButton::clicked, this, &SettingsDialog::openDirectory );
 }
@@ -404,7 +404,7 @@ void SettingsDialog::initFunctionality()
 		ui->cmbGeneralCheckUpdatePeriod->setCurrentIndex(3);
 	}
 	connect( ui->cmbGeneralCheckUpdatePeriod, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
-			[this](int index)
+			[](int index)
 			{
 				switch(index)
 				{
@@ -433,8 +433,8 @@ void SettingsDialog::initFunctionality()
 	{
 		ui->rdSigningBdoc->setChecked(true);
 	}
-	connect( ui->rdSigningBdoc, &QRadioButton::toggled, this, [this](bool checked) { if(checked) { Settings(qApp->applicationName()).setValueEx( "Client/Type", "bdoc", "bdoc" ); } } );
-	connect( ui->rdSigningAsice, &QRadioButton::toggled, this, [this](bool checked) { if(checked) { Settings(qApp->applicationName()).setValueEx( "Client/Type", "asice", "bdoc" ); } } );
+	connect( ui->rdSigningBdoc, &QRadioButton::toggled, this, [](bool checked) { if(checked) { Settings(qApp->applicationName()).setValueEx( "Client/Type", "bdoc", "bdoc" ); } } );
+	connect( ui->rdSigningAsice, &QRadioButton::toggled, this, [](bool checked) { if(checked) { Settings(qApp->applicationName()).setValueEx( "Client/Type", "asice", "bdoc" ); } } );
 
 	ui->chkGeneralTslRefresh->setChecked( qApp->confValue( Application::TSLOnlineDigest ).toBool() );
 	connect( ui->chkGeneralTslRefresh, &QCheckBox::toggled, []( bool checked ) { qApp->setConfValue( Application::TSLOnlineDigest, checked ); } );

--- a/client/widgets/CardPopup.cpp
+++ b/client/widgets/CardPopup.cpp
@@ -25,11 +25,10 @@
 #define WIDTH 365
 #define X_POSITION 110
 
-CardPopup::CardPopup(const TokenData &token, const QMap<QString, QSharedPointer<QCardInfo>> &cache, QWidget *parent)
+CardPopup::CardPopup(const QSet<QString> &cards, const QString &selectedCard, 
+	const QMap<QString, QSharedPointer<QCardInfo>> &cache, QWidget *parent)
 : StyledWidget(parent)
 {
-	auto cards = token.cards();
-
 	resize( WIDTH, (cards.size() - 1) * ROW_HEIGHT + ( (cards.size() > 1) ? BORDER_WIDTH : 0 ) );
 	move( X_POSITION, ROW_HEIGHT );
 	setStyleSheet( "border: solid rgba(217, 217, 216, 0.45); border-width: 0px 2px 2px 1px; background-color: rgba(255, 255, 255, 0.95);" );
@@ -37,7 +36,7 @@ CardPopup::CardPopup(const TokenData &token, const QMap<QString, QSharedPointer<
 	int i = 0;
 	for( auto card: cards )
 	{
-		if( card == token.card() )
+		if( card == selectedCard )
 			continue;
 		auto item = new QWidget( this );
 		item->resize( WIDTH - 2, ROW_HEIGHT - 1);

--- a/client/widgets/CardPopup.h
+++ b/client/widgets/CardPopup.h
@@ -23,9 +23,8 @@
 #include "widgets/CardWidget.h"
 #include "widgets/StyledWidget.h"
 
-#include <common/TokenData.h>
-
 #include <QMap>
+#include <QSet>
 #include <QSharedPointer>
 
 class CardPopup : public StyledWidget
@@ -33,8 +32,8 @@ class CardPopup : public StyledWidget
 	Q_OBJECT
 
 public:
-	explicit CardPopup(const TokenData &token, const QMap<QString, QSharedPointer<QCardInfo>> &cache,
-		QWidget *parent = nullptr);
+	explicit CardPopup(const QSet<QString> &cards, const QString &selectedCard,
+		const QMap<QString, QSharedPointer<QCardInfo>> &cache, QWidget *parent = nullptr);
 
 	void update(const QMap<QString, QSharedPointer<QCardInfo>> &cache);
 


### PR DESCRIPTION
DDKLIEN-142
- Handle eTokens with only auth or signing cert;
- If eToken has several auth/signing certs with the same
   card id, then select first valid (non-expired) cert;
- Card (e.g. eToken or smartcard) with signing cert is first
   option to select as a default card; if no cards with signing cert
   is present, only then the card with only auth cert is selected.

Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>