### PR TITLE
Print summary hidden by default

### DIFF
--- a/client/MainWindow.cpp
+++ b/client/MainWindow.cpp
@@ -1087,6 +1087,7 @@ void MainWindow::showSettings(int page)
 			}
 	);
 	connect(&dlg, &SettingsDialog::removeOldCert, this,	&MainWindow::removeOldCert);
+	connect(&dlg, &SettingsDialog::togglePrinting, ui->signContainerPage, &ContainerPage::togglePrinting);
 	dlg.exec();
 }
 

--- a/client/dialogs/SettingsDialog.cpp
+++ b/client/dialogs/SettingsDialog.cpp
@@ -29,7 +29,6 @@
 #include "Styles.h"
 #include "dialogs/CertificateDetails.h"
 #include "dialogs/FirstRun.h"
-#include "widgets/ContainerPage.h"
 #include "effects/Overlay.h"
 #include "effects/FadeInNotification.h"
 
@@ -489,19 +488,8 @@ void SettingsDialog::initFunctionality()
 	updateProxy();
 	ui->chkIgnoreAccessCert->setChecked( Application::confValue( Application::PKCS12Disable, false ).toBool() );
 
-	ui->chkShowPrintSummary->setChecked( Settings(qApp->applicationName()).value( "Client/ShowPrintSummary", "false" ).toBool() );
-	
-	connect( ui->chkShowPrintSummary, &QCheckBox::toggled, this, [this](bool checked) { 
-		for (QWidget *widget : qApp->allWidgets())
-		{
-			if(qobject_cast<ContainerPage*>(widget))
-			{
-				const QEvent::Type myEventType = QEvent::Type(QEvent::User);
-				qApp->sendEvent(widget, new QEvent(myEventType ));
-				break;
-			}
-		}
-	} );
+	ui->chkShowPrintSummary->setChecked(Settings(qApp->applicationName()).value( "Client/ShowPrintSummary", "false" ).toBool());
+	connect(ui->chkShowPrintSummary, &QCheckBox::toggled, this, &SettingsDialog::togglePrinting);
 
 	updateDiagnostics();
 }

--- a/client/dialogs/SettingsDialog.cpp
+++ b/client/dialogs/SettingsDialog.cpp
@@ -29,6 +29,7 @@
 #include "Styles.h"
 #include "dialogs/CertificateDetails.h"
 #include "dialogs/FirstRun.h"
+#include "widgets/ContainerPage.h"
 #include "effects/Overlay.h"
 #include "effects/FadeInNotification.h"
 
@@ -154,6 +155,7 @@ void SettingsDialog::initUI()
 	ui->lblSigningFileType->setFont(headerFont);
 	ui->lblSigningRole->setFont(headerFont);
 	ui->lblSigningAddress->setFont(headerFont);
+	ui->chkShowPrintSummary->setFont(regularFont);
 
 	ui->rdSigningAsice->setFont(regularFont);
 	ui->rdSigningBdoc->setFont(regularFont);
@@ -487,6 +489,20 @@ void SettingsDialog::initFunctionality()
 	updateProxy();
 	ui->chkIgnoreAccessCert->setChecked( Application::confValue( Application::PKCS12Disable, false ).toBool() );
 
+	ui->chkShowPrintSummary->setChecked( Settings(qApp->applicationName()).value( "Client/ShowPrintSummary", "false" ).toBool() );
+	
+	connect( ui->chkShowPrintSummary, &QCheckBox::toggled, this, [this](bool checked) { 
+		for (QWidget *widget : qApp->allWidgets())
+		{
+			if(qobject_cast<ContainerPage*>(widget))
+			{
+				const QEvent::Type myEventType = QEvent::Type(QEvent::User);
+				qApp->sendEvent(widget, new QEvent(myEventType ));
+				break;
+			}
+		}
+	} );
+
 	updateDiagnostics();
 }
 
@@ -557,6 +573,8 @@ void SettingsDialog::save()
 		ui->txtSigningCountry->text(),
 		ui->txtSigningZipCode->text(),
 		true );
+
+	Settings(qApp->applicationName()).setValue("Client/ShowPrintSummary", ui->chkShowPrintSummary->isChecked() );
 }
 
 void SettingsDialog::saveProxy()

--- a/client/dialogs/SettingsDialog.h
+++ b/client/dialogs/SettingsDialog.h
@@ -55,6 +55,7 @@ private Q_SLOTS:
 signals:
 	void langChanged(const QString& lang);
 	void removeOldCert();
+	void togglePrinting(bool enable);
 
 private:
 	void checkConnection();

--- a/client/dialogs/SettingsDialog.ui
+++ b/client/dialogs/SettingsDialog.ui
@@ -1060,7 +1060,7 @@ QRadioButton::indicator::checked {
           <property name="geometry">
            <rect>
             <x>21</x>
-            <y>220</y>
+            <y>245</y>
             <width>150</width>
             <height>21</height>
            </rect>
@@ -1085,7 +1085,7 @@ QRadioButton::indicator::checked {
           <property name="geometry">
            <rect>
             <x>21</x>
-            <y>248</y>
+            <y>273</y>
             <width>330</width>
             <height>31</height>
            </rect>
@@ -1115,7 +1115,7 @@ background-color: #FFFFFF;
           <property name="geometry">
            <rect>
             <x>20</x>
-            <y>300</y>
+            <y>325</y>
             <width>70</width>
             <height>21</height>
            </rect>
@@ -1140,7 +1140,7 @@ background-color: #FFFFFF;
           <property name="geometry">
            <rect>
             <x>100</x>
-            <y>330</y>
+            <y>355</y>
             <width>670</width>
             <height>31</height>
            </rect>
@@ -1170,7 +1170,7 @@ background-color: #FFFFFF;
           <property name="geometry">
            <rect>
             <x>100</x>
-            <y>365</y>
+            <y>390</y>
             <width>670</width>
             <height>31</height>
            </rect>
@@ -1200,7 +1200,7 @@ background-color: #FFFFFF;
           <property name="geometry">
            <rect>
             <x>100</x>
-            <y>400</y>
+            <y>425</y>
             <width>670</width>
             <height>31</height>
            </rect>
@@ -1230,7 +1230,7 @@ background-color: #FFFFFF;
           <property name="geometry">
            <rect>
             <x>100</x>
-            <y>435</y>
+            <y>460</y>
             <width>670</width>
             <height>31</height>
            </rect>
@@ -1260,7 +1260,7 @@ background-color: #FFFFFF;
           <property name="geometry">
            <rect>
             <x>21</x>
-            <y>337</y>
+            <y>362</y>
             <width>65</width>
             <height>16</height>
            </rect>
@@ -1285,7 +1285,7 @@ background-color: #FFFFFF;
           <property name="geometry">
            <rect>
             <x>21</x>
-            <y>372</y>
+            <y>397</y>
             <width>65</width>
             <height>16</height>
            </rect>
@@ -1310,7 +1310,7 @@ background-color: #FFFFFF;
           <property name="geometry">
            <rect>
             <x>21</x>
-            <y>407</y>
+            <y>432</y>
             <width>65</width>
             <height>16</height>
            </rect>
@@ -1335,7 +1335,7 @@ background-color: #FFFFFF;
           <property name="geometry">
            <rect>
             <x>21</x>
-            <y>442</y>
+            <y>467</y>
             <width>75</width>
             <height>16</height>
            </rect>
@@ -1354,6 +1354,45 @@ background-color: #FFFFFF;
           </property>
           <property name="text">
            <string>Zip</string>
+          </property>
+         </widget>
+         <widget class="QCheckBox" name="chkShowPrintSummary">
+          <property name="geometry">
+           <rect>
+            <x>20</x>
+            <y>210</y>
+            <width>700</width>
+            <height>16</height>
+           </rect>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>700</width>
+            <height>16</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>700</width>
+            <height>16</height>
+           </size>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">QCheckBox::indicator {
+    width: 14px;
+    height: 14px;
+}
+
+QCheckBox::indicator:unchecked {
+    image: url(:/images/icon_checkbox.png);
+}
+
+QCheckBox::indicator:checked {
+    image: url(:/images/icon_checkbox_check.png);
+}</string>
+          </property>
+          <property name="text">
+           <string>Show print summary</string>
           </property>
          </widget>
         </widget>

--- a/client/translations/en.ts
+++ b/client/translations/en.ts
@@ -1769,6 +1769,10 @@ Control code: %1</translation>
         <translation>If you want to change the digital signature format then it should be done before adding signable files to the container. Otherwise the document will be created in the previous default format. When adding signatures, it is no longer possible to change the format of the document.</translation>
     </message>
     <message>
+        <source>Show print summary</source>
+        <translation>Show print summary</translation>
+    </message>
+    <message>
         <source>Role</source>
         <translation>Role</translation>
     </message>

--- a/client/translations/et.ts
+++ b/client/translations/et.ts
@@ -1777,6 +1777,10 @@ Kontrollkood: %1</translation>
         <translation>Kui soovid vormingut muuta, siis tee seda enne, kui valid failid allkirjastamiseks. Vastasel juhul jääb kehtima varasem vaikevorming. Juba allkirjastatud dokumendile allkirja lisades dokumendi vormingut muuta ei saa, alati jääb kehtima algne vorming.</translation>
     </message>
     <message>
+        <source>Show print summary</source>
+        <translation>Näita kinnituslehte</translation>
+    </message>
+    <message>
         <source>Role</source>
         <translation>Roll</translation>
     </message>

--- a/client/translations/ru.ts
+++ b/client/translations/ru.ts
@@ -1768,6 +1768,10 @@ Kонтрольны код: %1</translation>
         <translation>Если Вы желаете изменить формат цифровой подписи, это нужно сделать до того, как Вы добавите в контейнер подписываемый файл. В противном случае будет действовать формат подписи по умолчанию. Если документ уже подписан, то при добавлении к нему второй подписи формат подписи изменить невозможно.</translation>
     </message>
     <message>
+        <source>Show print summary</source>
+        <translation>Показать подтверждающий лист</translation>
+    </message>
+    <message>
         <source>Role</source>
         <translation>Роль</translation>
     </message>

--- a/client/widgets/ContainerPage.cpp
+++ b/client/widgets/ContainerPage.cpp
@@ -272,19 +272,6 @@ void ContainerPage::resizeEvent( QResizeEvent *event )
 		elideFileName();
 }
 
-bool ContainerPage::event(QEvent *event)
-{
-	if( event->type() == QEvent::User )
-	{
-		if( ui->summary->isHidden() )
-			ui->summary->show();
-		else
-			ui->summary->hide();
-	}
-
-	return QWidget::event(event); 
-}
-
 void ContainerPage::changeEvent(QEvent* event)
 {
 	if (event->type() == QEvent::LanguageChange)
@@ -563,6 +550,11 @@ void ContainerPage::updatePanes(ContainerState state)
 	}
 
 	translateLabels();
+}
+
+void ContainerPage::togglePrinting(bool enable)
+{
+	ui->summary->setVisible(enable);
 }
 
 void ContainerPage::translateLabels()

--- a/client/widgets/ContainerPage.cpp
+++ b/client/widgets/ContainerPage.cpp
@@ -193,6 +193,11 @@ void ContainerPage::init()
 	connect(ui->navigateToContainer, &LabelButton::clicked, this, &ContainerPage::forward);
 	connect(ui->convert, &LabelButton::clicked, this, &ContainerPage::forward);
 	connect(ui->containerFile, &QLabel::linkActivated, this, &ContainerPage::browseContainer );
+
+	if( Settings(qApp->applicationName()).value( "Client/ShowPrintSummary", "false" ).toBool() )
+		ui->summary->show();
+	else
+		ui->summary->hide();
 }
 
 void ContainerPage::initContainer( const QString &file, const QString &suffix )
@@ -265,6 +270,19 @@ void ContainerPage::resizeEvent( QResizeEvent *event )
 
 	if(event->oldSize().width() != event->size().width())
 		elideFileName();
+}
+
+bool ContainerPage::event(QEvent *event)
+{
+	if( event->type() == QEvent::User )
+	{
+		if( ui->summary->isHidden() )
+			ui->summary->show();
+		else
+			ui->summary->hide();
+	}
+
+	return QWidget::event(event); 
 }
 
 void ContainerPage::changeEvent(QEvent* event)
@@ -452,6 +470,7 @@ void ContainerPage::updatePanes(ContainerState state)
 {
 	auto buttonWidth = ui->changeLocation->width();
 	bool resize = false;
+	bool showPrintSummary = Settings(qApp->applicationName()).value( "Client/ShowPrintSummary", "false" ).toBool();
 
 	switch( state )
 	{
@@ -473,7 +492,10 @@ void ContainerPage::updatePanes(ContainerState state)
 
 		ui->changeLocation->show();
 		ui->leftPane->init(fileName, "Content of the envelope");
-		showButtons( { ui->cancel, ui->convert, ui->navigateToContainer, ui->email, ui->summary } );
+		if( showPrintSummary )
+			showButtons( { ui->cancel, ui->convert, ui->navigateToContainer, ui->email, ui->summary } );
+		else
+			showButtons( { ui->cancel, ui->convert, ui->navigateToContainer, ui->email } );
 		hideButtons( { ui->save } );
 		showRightPane( ItemSignature, "Container is not signed");
 		break;
@@ -486,7 +508,10 @@ void ContainerPage::updatePanes(ContainerState state)
 		ui->leftPane->init(fileName, "Content of the envelope");
 		showRightPane( ItemSignature, "Container's signatures" );
 		hideButtons( { ui->save } );
-		showButtons( { ui->cancel, ui->convert, ui->navigateToContainer, ui->email, ui->summary } );
+		if( showPrintSummary )
+			showButtons( { ui->cancel, ui->convert, ui->navigateToContainer, ui->email, ui->summary } );
+		else
+			showButtons( { ui->cancel, ui->convert, ui->navigateToContainer, ui->email } );
 		break;
 	case UnencryptedContainer:
 		cancelText = "STARTING";

--- a/client/widgets/ContainerPage.h
+++ b/client/widgets/ContainerPage.h
@@ -69,11 +69,11 @@ signals:
 
 public slots:
 	void clearPopups();
+	void togglePrinting(bool enable);
 
 protected:
 	void resizeEvent( QResizeEvent *event ) override;
 	void changeEvent(QEvent* event) override;
-	bool event(QEvent *event) override;
 
 private:
 	void addError(const SignatureItem* item, QMap<ria::qdigidoc4::WarningType, int> &errors);

--- a/client/widgets/ContainerPage.h
+++ b/client/widgets/ContainerPage.h
@@ -73,6 +73,7 @@ public slots:
 protected:
 	void resizeEvent( QResizeEvent *event ) override;
 	void changeEvent(QEvent* event) override;
+	bool event(QEvent *event) override;
 
 private:
 	void addError(const SignatureItem* item, QMap<ria::qdigidoc4::WarningType, int> &errors);


### PR DESCRIPTION
DDKLIEN-132: Show 'Print summary' button for signed documents only if
the feature is selected in the Settings dialog.

Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>
Signed-off-by: Oleg Prokofjev <oleg@aktors.ee>
