### PR TITLE
Save user's picture in the original resolution

### DIFF
--- a/client/MainWindow.h
+++ b/client/MainWindow.h
@@ -73,7 +73,7 @@ private Q_SLOTS:
 	void operation(int op, bool started);
 	void pageSelected( PageIcon *const );
 	void photoClicked( const QPixmap *photo );
-	void savePhoto( const QPixmap *photo );
+	void savePhoto();
 	void showCardStatus();
 	void updateMyEid();
 	void warningClicked(const QString &link);

--- a/client/widgets/CardWidget.cpp
+++ b/client/widgets/CardWidget.cpp
@@ -56,7 +56,7 @@ CardWidget::CardWidget( const QString &id, QWidget *parent )
 
 	connect(ui->cardPhoto, &LabelButton::clicked, this, [this]() { emit photoClicked(ui->cardPhoto->pixmap()); });
 	connect(ui->cardPhoto, &LabelButton::entered, this, [this]() { 
-		if(!ui->cardPhoto->property("PICTURE").isValid())
+		if(!ui->cardPhoto->pixmap())
 			ui->load->show(); 
 		});
 	connect(ui->cardPhoto, &LabelButton::left, this, [this]() { ui->load->hide(); });
@@ -162,6 +162,5 @@ void CardWidget::update(const QSharedPointer<const QCardInfo> &ci, const QString
 void CardWidget::showPicture( const QPixmap &pix )
 {
 	clearSeal();
-	ui->cardPhoto->setProperty( "PICTURE", pix );
 	ui->cardPhoto->setPixmap( pix.scaled( 34, 44, Qt::IgnoreAspectRatio, Qt::SmoothTransformation ) );
 }

--- a/client/widgets/InfoStack.cpp
+++ b/client/widgets/InfoStack.cpp
@@ -139,7 +139,6 @@ void InfoStack::focusEvent(int eventType)
 void InfoStack::showPicture( const QPixmap &pixmap )
 {
 	clearAlternateIcon();
-	ui->photo->setProperty( "PICTURE", pixmap );
 	ui->photo->setPixmap( pixmap.scaled( 120, 150, Qt::IgnoreAspectRatio, Qt::SmoothTransformation ) );
 	pictureText = "SAVE THE PICTURE";
 	ui->btnPicture->setText(tr(qPrintable(pictureText)));


### PR DESCRIPTION
Fix for https://github.com/open-eid/DigiDoc4-Client/issues/256
- Save user's picture in original resolution, not scaled down
- Propose system's default folder for saving pictures

Signed-off-by: Toomas Uudisaru <toomas.uudisaru@aktors.ee>