### PR TITLE
Addresses issue #262 (fix build errors on Qt version>5.11)

### DIFF
--- a/client/Styles.h
+++ b/client/Styles.h
@@ -24,6 +24,7 @@
 #include <QtCore/QtGlobal>
 #include <QFont>
 #include <QPixmap>
+#include <QStyle>
 
 class PictureInterface
 {

--- a/client/dialogs/PinUnblock.cpp
+++ b/client/dialogs/PinUnblock.cpp
@@ -25,6 +25,7 @@
 
 #include <QLabel>
 #include <QList>
+#include <QtGui/QRegExpValidator>
 
 
 struct InfoLine

--- a/client/dialogs/Updater.cpp
+++ b/client/dialogs/Updater.cpp
@@ -41,6 +41,7 @@
 #include <QtNetwork/QNetworkReply>
 #include <QtNetwork/QSslKey>
 #include <QtGui/QPainter>
+#include <QtGui/QRegExpValidator>
 #include <QtWidgets/QPushButton>
 
 #include <openssl/evp.h>

--- a/client/widgets/OtherData.h
+++ b/client/widgets/OtherData.h
@@ -21,6 +21,7 @@
 
 #include <QWidget>
 #include <QPainter>
+#include <QStyleOption>
 
 namespace Ui {
 class OtherData;


### PR DESCRIPTION
DigiDoc4 build fails on systems that use Qt 5.11

/common submodule was already updated upstream, but not updated in this project. However, even with this change, build still fails due to the lack of explicit imports. I've tried to identify them all all tested the build with Qt 5.11, with the changes in this PR and latest /common/qtsingleapplication build on Fedora 29 passes with flying colors and also compiles without issued on earlier releases.

I don't have a lot of experience with C++ or Qt and welcome any comments about this PR and whether the location of imports (Header/Implementation) is appropriate or not.

Currently I am applying a patch for Fedora builds as part of package build process, but think that merging them upstream can be beneficial.

Looking forward to any feedback.