### PR TITLE
OMNIKEY 3x21 and 6121 Smart Card Reader are not pinpad readers

### DIFF
--- a/client/crypto/LdapSearch.cpp
+++ b/client/crypto/LdapSearch.cpp
@@ -25,6 +25,7 @@
 #include <QtNetwork/QSslCertificate>
 
 #ifdef Q_OS_WIN
+#undef UNICODE
 #include <Windows.h>
 #include <Winldap.h>
 #include <Winber.h>

--- a/client/dialogs/SettingsDialog.cpp
+++ b/client/dialogs/SettingsDialog.cpp
@@ -57,6 +57,7 @@
 
 #ifdef Q_OS_WIN
 #include <qt_windows.h>
+#include <shellapi.h>
 #include <QProcess>
 #endif
 


### PR DESCRIPTION
macOS 10.13 ships with ccid driver 1.4.27 (fixed in 1.4.29) and this version identifies these readers wrongly as pinpad readers.

IB-5365

Signed-off-by: Raul Metsma <raul@metsma.ee>