### PR TITLE
.gitmodules: revert path local change

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "cmake"]
 	path = cmake
-	url = ../cmake
+	url = https://github.com/open-eid/cmake
 [submodule "common"]
 	path = common
-	url = ../qt-common
+	url = https://github.com/open-eid/qt-common
 [submodule "extensions"]
 	path = extensions
-	url = ../digidoc-extensions
+	url = https://github.com/open-eid/digidoc-extensions


### PR DESCRIPTION
Revert `.gitmodules` change to local in #266 via 98444d30

Change not mentioned in commit log or PR details, so apparently a mistake.