### PR TITLE
Python2 is unsupported and Debian requires python3-nautilus package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,7 @@ Architecture: any
 Depends:
  opensc-pkcs11,
  fonts-liberation,
- python-nautilus,
+ python3-nautilus | python-nautilus,
  ${shlibs:Depends},
  ${misc:Depends}
 Replaces:


### PR DESCRIPTION
Fixes #715

Signed-off-by: Raul Metsma <raul@metsma.ee>