### PR TITLE
Added explicit imports for QPainterPath to fix builds with Qt ≥ 5.15

### DIFF
--- a/client/widgets/CheckBox.cpp
+++ b/client/widgets/CheckBox.cpp
@@ -22,6 +22,7 @@
 #include <QBrush>
 #include <QPaintEvent>
 #include <QPainter>
+#include <QPainterPath>
 #include <QStyleOptionButton>
 
 CheckBox::CheckBox(QWidget *parent)

--- a/client/widgets/MainAction.cpp
+++ b/client/widgets/MainAction.cpp
@@ -24,6 +24,7 @@
 
 #include <QtCore/QSettings>
 #include <QtGui/QPainter>
+#include <QtGui/QPainterPath>
 #include <QtGui/QPaintEvent>
 
 using namespace ria::qdigidoc4;


### PR DESCRIPTION
Addresses #912 explicit imports fix the build on newer Qt versions, only two files affected.

This would fix packaging issues on Arch and Fedora

P.S. hope I've gotten the sign-off right this time.