### PR TITLE
Support BSD

### DIFF
--- a/client/Application.cpp
+++ b/client/Application.cpp
@@ -712,7 +712,7 @@ void Application::mailTo( const QUrl &url )
 		default: break;
 		}
 	}
-#elif defined(Q_OS_LINUX)
+#elif defined(Q_OS_UNIX)
 	QByteArray thunderbird;
 	QProcess p;
 	QStringList env = QProcess::systemEnvironment();

--- a/client/dialogs/CertificateDetails.cpp
+++ b/client/dialogs/CertificateDetails.cpp
@@ -207,7 +207,7 @@ QString CertificateDetails::decodeCN(const QString &cn)
 #ifndef Q_OS_MAC
 void CertificateDetails::showCertificate(const SslCertificate &cert, QWidget *parent, const QString &suffix)
 {
-#ifdef Q_OS_LINUX
+#ifdef Q_OS_UNIX
 	CertificateDetails(cert, parent).exec();
 #else
 	Q_UNUSED(parent);

--- a/client/dialogs/MobileProgress.cpp
+++ b/client/dialogs/MobileProgress.cpp
@@ -93,7 +93,7 @@ MobileProgress::MobileProgress(QWidget *parent)
 	d->info->setFont(Styles::font(Styles::Regular, 14));
 	d->controlCode->setFont(Styles::font(Styles::Regular, 14));
 	d->signProgressBar->setFont(d->info->font());
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
 const auto styleSheet = R"(QProgressBar {
 background-color: #d3d3d3;
 border-style: solid;

--- a/client/dialogs/SettingsDialog.cpp
+++ b/client/dialogs/SettingsDialog.cpp
@@ -113,7 +113,7 @@ SettingsDialog::SettingsDialog(QWidget *parent)
 	ui->txtAccessCert->setFont(regularFont);
 	ui->btInstallManually->setFont(condensed12);
 	ui->btShowCertificate->setFont(condensed12);
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
 	ui->btInstallManually->setStyleSheet("background-color: #d3d3d3");
 	ui->btShowCertificate->setStyleSheet("background-color: #d3d3d3");
 #endif

--- a/client/dialogs/SmartIDProgress.cpp
+++ b/client/dialogs/SmartIDProgress.cpp
@@ -97,7 +97,7 @@ SmartIDProgress::SmartIDProgress(QWidget *parent)
 	d->info->setFont(Styles::font(Styles::Regular, 14));
 	d->controlCode->setFont(Styles::font(Styles::Regular, 14));
 	d->signProgressBar->setFont(d->info->font());
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
 const auto styleSheet = R"(QProgressBar {
 background-color: #d3d3d3;;
 border-style: solid;

--- a/client/dialogs/WarningDialog.cpp
+++ b/client/dialogs/WarningDialog.cpp
@@ -89,8 +89,8 @@ void WarningDialog::addButton(const QString& label, int ret, bool red)
 		setLayoutDirection(Qt::RightToLeft);
 #endif
 	} else {
-// For macOS and Linux all positive buttons should be on the right side of the dialog window
-#if defined(Q_OS_MAC) || defined(Q_OS_LINUX)
+// For macOS, Linux and BSD all positive buttons should be on the right side of the dialog window
+#if defined(Q_OS_UNIX)
 		setLayoutDirection(Qt::RightToLeft);
 #endif
 	}


### PR DESCRIPTION
- Detect non-Mac and non-Windows as Unix to support BSDs next to Linux
- Extend Linux specific Thunderbird support to UNIX to include BSDs
- Enable progressbar stylesheets on BSDs just like on Linux
- Right-align positive buttons on BSDs as well

The first commit is required to unbreak the build on OpenBSD.
The others are optional fixes to improve user experience and code
consistency.

I am now running `qdigidoc4-4.2.11` with `libdigidocpp-3.14.8` on
OpenBSD/amd64 7.1.

I have successfully encrypted and decrypted a file on OpenBSD and
Linux (NixOS 21.11), respectively.

I can view my card's details and inspect the email forwarding setting.

Signing files, however, causes a crash due to a use-after-free() bug;
this happens with `digidoc-tool create --file=./hello.txt hello.asice`
from `libdigidocpp` as well as the graphical `qdigidoc4` interface.

On Linux, signing files also fails with `qdigidoc4` showing a generic
error message.  I have not looked into this (yet).
