### PR TITLE
Include missing <QRegExp> to fix Qt6 build

### DIFF
--- a/client/Application.cpp
+++ b/client/Application.cpp
@@ -46,6 +46,7 @@ class MacMenuBar {};
 #include <qtsingleapplication/src/qtlocalpeer.h>
 
 #include <QAction>
+#include <QRegExp>
 #include <QtCore/QFileInfo>
 #include <QtCore/QJsonArray>
 #include <QtCore/QJsonDocument>


### PR DESCRIPTION
```
.../client/Application.cpp:727:19: error: use of undeclared identifier 'QRegExp'
        if( env.indexOf( QRegExp("KDE_FULL_SESSION.*") ) != -1 )
                         ^
.../Application.cpp:738:24: error: use of undeclared identifier 'QRegExp'
        else if( env.indexOf( QRegExp("GNOME_DESKTOP_SESSION_ID.*") ) != -1 )
                              ^
2 errors generated.
```

No idea why this builds fine against Qt5, but Qt6 fails as per above.

Qt6 provides this header under Qt5Core5Compact.

Signed-off-by: Klemens Nanni <klemens@posteo.de>
