### PR TITLE
Fixes error: ‘optional’ in namespace ‘std’ does not name a template type

### DIFF
--- a/client/Application.cpp
+++ b/client/Application.cpp
@@ -41,6 +41,7 @@ class MacMenuBar {};
 #include "effects/Overlay.h"
 
 #include <common/Configuration.h>
+#include <optional>
 
 #include <digidocpp/Container.h>
 #include <digidocpp/XmlConf.h>


### PR DESCRIPTION
I am getting this error in EndeavorOS/Arch Linux when running  cmake --build build
```
/home/vivek/Downloads/DigiDoc4-Client/client/Application.cpp:296:14: error: ‘optional’ in namespace ‘std’ does not name a template type
  296 |         std::optional<std::string> log;
      |              ^~~~~~~~
/home/vivek/Downloads/DigiDoc4-Client/client/Application.cpp:76:1: note: ‘std::optional’ is defined in header ‘<optional>’; did you forget to ‘#include <optional>’?
   75 | #include <QtWidgets/QToolTip>
  +++ |+#include <optional>
   76 | 

```
Adding  missing <optional> header in /DigiDoc4-Client/client/Application.cpp fixes this issue.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Please update Signed-off-by info and read the common contributing guidelines
before you continue https://github.com/open-eid/.github/blob/master/CONTRIBUTING.md!
-->

Signed-off-by: Vivek Kiran Ballakur <thevivekkiran@gmail.com>
