### PR TITLE
Revert "Fix macos bundle display name in Finder (#1250)"

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -22,11 +22,8 @@ set(SCHEMAS
 	../schema/recipients.fbs
 	../schema/header.fbs
 )
-if(APPLE)
-	set(PROJECT_NAME DigiDoc4)
-endif()
 add_executable(${PROJECT_NAME} WIN32 MACOSX_BUNDLE
-	qdigidoc4.rc
+	${PROJECT_NAME}.rc
 	${SOURCES}
 	${WIDGETS}
 	images/images.qrc
@@ -185,9 +182,9 @@ if( APPLE )
 			$<TARGET_BUNDLE_CONTENT_DIR:${PROJECT_NAME}>/PlugIns/*/*
 			$<TARGET_BUNDLE_CONTENT_DIR:${PROJECT_NAME}>/Library/QuickLook/DigiDocQL.qlgenerator
 		COMMAND if echo \"$$SIGNCERT\" | grep -q "Developer ID" \; then
-				codesign -f -s \"$$SIGNCERT\" $<TARGET_BUNDLE_DIR:${PROJECT_NAME}> --entitlements ${CMAKE_SOURCE_DIR}/qdigidoc4.eToken.entitlements\;
+				codesign -f -s \"$$SIGNCERT\" $<TARGET_BUNDLE_DIR:${PROJECT_NAME}> --entitlements ${CMAKE_SOURCE_DIR}/${PROJECT_NAME}.eToken.entitlements\;
 			else
-				codesign -f -s \"$$SIGNCERT\" $<TARGET_BUNDLE_DIR:${PROJECT_NAME}> --entitlements ${CMAKE_SOURCE_DIR}/qdigidoc4.entitlements\;
+				codesign -f -s \"$$SIGNCERT\" $<TARGET_BUNDLE_DIR:${PROJECT_NAME}> --entitlements ${CMAKE_SOURCE_DIR}/${PROJECT_NAME}.entitlements\;
 			fi
 	)
 

--- a/client/mac/Info.plist.cmake
+++ b/client/mac/Info.plist.cmake
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>DigiDoc4</string>
+	<string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleSupportedPlatforms</key>
@@ -32,6 +32,8 @@
 	<true/>
 	<key>NSAppleEventsUsageDescription</key>
 	<string>DigiDoc4 can use AppleScript to talk with apps, for example to insert attachments to emails.</string>
+	<key>LSHasLocalizedDisplayName</key>
+	<true/>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
 	<key>LSMinimumSystemVersion</key>

--- a/client/mac/Resources/en.lproj/InfoPlist.strings
+++ b/client/mac/Resources/en.lproj/InfoPlist.strings
@@ -1,0 +1,4 @@
+/* Localized versions of Info.plist keys */
+
+CFBundleName = "DigiDoc4";
+CFBundleDisplayName = "DigiDoc4";

--- a/client/mac/Resources/et.lproj/InfoPlist.strings
+++ b/client/mac/Resources/et.lproj/InfoPlist.strings
@@ -1,0 +1,4 @@
+/* Localized versions of Info.plist keys */
+
+CFBundleName = "DigiDoc4";
+CFBundleDisplayName = "DigiDoc4";

--- a/client/mac/Resources/ru.lproj/InfoPlist.strings
+++ b/client/mac/Resources/ru.lproj/InfoPlist.strings
@@ -1,0 +1,4 @@
+/* Localized versions of Info.plist keys */
+
+CFBundleName = "DigiDoc4";
+CFBundleDisplayName = "DigiDoc4";


### PR DESCRIPTION
This reverts commit 19a022279a8a66aaa73477e6518fc691a28ff3ec.

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Please update Signed-off-by info and read the common contributing guidelines
before you continue https://github.com/open-eid/.github/blob/master/CONTRIBUTING.md!
-->

Signed-off-by: Raul Metsma <raul@metsma.ee>
