### PR TITLE
actions: Add Fedora 42 to build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
     container: fedora:${{ matrix.container }}
     strategy:
       matrix:
-        container: [40, 41]
+        container: [40, 41, 42]
     steps:
     - name: Install Deps
       run: |


### PR DESCRIPTION
Fedora 42 is about to be released in ~6 weeks.

Signed-off-by: Priit Laes <plaes@plaes.org>