### PR TITLE
Make finding icon at runtime more robust.

### DIFF
--- a/client/Application.cpp
+++ b/client/Application.cpp
@@ -313,6 +313,7 @@ Application::Application( int &argc, char **argv )
 {
 	setApplicationName(QStringLiteral("qdigidoc4"));
 	setApplicationVersion(QStringLiteral(VERSION_STR));
+	setDesktopFileName("ee.ria.qdigidoc4");
 	setOrganizationDomain(QStringLiteral("ria.ee"));
 	setOrganizationName(QStringLiteral("RIA"));
 	setWindowIcon(QIcon(QStringLiteral(":/images/Icon.svg")));


### PR DESCRIPTION
By default, the file name (argv[0]) of the application is used to compute its name, which can break if a distribution wraps the binary with a shell script to set some environment variables, as used in Guix for example.

* client/main.cpp (main): Explicitly set the desktop file name.

Signed-off-by: Maxim Cournoyer <maxim@guixotic.coop>
