### PR TITLE
Fix date format year placeholder

### DIFF
--- a/extensions/DigiDocQL/PreviewViewController.mm
+++ b/extensions/DigiDocQL/PreviewViewController.mm
@@ -100,7 +100,7 @@ public:
         NSISO8601DateFormatter *dfrom = [[NSISO8601DateFormatter alloc] init];
         NSDateFormatter *dto = [[NSDateFormatter alloc] init];
         [dto setTimeZone: [NSTimeZone defaultTimeZone]];
-        [dto setDateFormat:@"YYYY-MM-dd HH:mm:ss z"];
+        [dto setDateFormat:@"yyyy-MM-dd HH:mm:ss z"];
 
         NSMutableString *h = [NSMutableString stringWithString:@R"(
 <html><head><meta charset="UTF-8"><style>


### PR DESCRIPTION
Change date format from YYYY to yyyy. The uppercase YYYY represents the ISO 8601 week-based year, which can differ from the calendar year near year boundaries. Using lowercase yyyy ensures the correct calendar year is displayed.
